### PR TITLE
Fix parse error of `perm-batch-size`

### DIFF
--- a/plink.c
+++ b/plink.c
@@ -9526,7 +9526,7 @@ int32_t main(int32_t argc, char** argv) {
 	  goto main_ret_INVALID_CMDLINE_A;
 	}
 	pfilter = dxx;
-      } else if (!memcmp(argptr2, "erm-batch-size", 1)) {
+      } else if (!memcmp(argptr2, "erm-batch-size", 15)) {
 	if (enforce_param_ct_range(param_ct, argv[cur_arg], 1, 1)) {
 	  goto main_ret_INVALID_CMDLINE_2A;
 	}


### PR DESCRIPTION
* Due to subtle bug, the program accepts undefined commands like `--pe` as `--perm-batch-size`.
* Just fixed wrong command length for `memcmp`.
```
% plink --pe -1
PLINK v1.90b3p 64-bit (27 Aug 2014)        https://www.cog-genomics.org/plink2
(C) 2005-2014 Shaun Purcell, Christopher Chang   GNU General Public License v3
Logging to plink.log.
Error: Invalid --perm-batch-size parameter '-1'.
For more information, try 'plink --help [flag name]' or 'plink --help | more'.
```