### PR TITLE
Switched from distutils to setuptools in Pgenlib

### DIFF
--- a/2.0/Python/setup.py
+++ b/2.0/Python/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
-from distutils.core import setup
-from distutils.extension import Extension
+from setuptools import setup
+from setuptools.extension import Extension
 from Cython.Build import cythonize
 
 import numpy as np


### PR DESCRIPTION
This pull request switches from `distutils` to `setuptools` in `setup.py` for Pgenlib. The main advantage of switching is that one can more easily create `egg` or `wheel` packages for saving on private Python package repos.