### PR TITLE
Change the first-compile script to use the standard Makefile

### DIFF
--- a/1.9/plink_first_compile
+++ b/1.9/plink_first_compile
@@ -25,4 +25,4 @@ make
 
 # Compile
 cd ../1.9
-make plink
+make -f Makefile.std plink


### PR DESCRIPTION
This PR changes the first-compile script to use the standard Makefile. This suppresses a link error because the old Makefile tries to build using some old 32-bit headers. 