### PR TITLE
Fix a bug in RcppExports.R

### DIFF
--- a/2.0/pgenlibr/R/RcppExports.R
+++ b/2.0/pgenlibr/R/RcppExports.R
@@ -57,12 +57,12 @@ ReadAlleles <- function(pgen, acbuf, variant_num, phasepresent_buf = NULL) {
     invisible(.Call(`_pgenlibr_ReadAlleles`, pgen, acbuf, variant_num, phasepresent_buf))
 }
 
-ReadIntList <- function(pgen, variant_subset) {
-    .Call(`_pgenlibr_ReadIntList`, pgen, variant_subset)
+ReadIntList <- function(pgen, buf, variant_subset) {
+    .Call(`_pgenlibr_ReadIntList`, pgen, buf, variant_subset)
 }
 
-ReadList <- function(pgen, variant_subset) {
-    .Call(`_pgenlibr_ReadList`, pgen, variant_subset)
+ReadList <- function(pgen, buf, variant_subset) {
+    .Call(`_pgenlibr_ReadList`, pgen, buf, variant_subset)
 }
 
 VariantScores <- function(pgen, weights, variant_subset = NULL) {


### PR DESCRIPTION
`ReadList` and `ReadIntList` should take a buffer (`buf`) and pass it to the corresponding C++ function.