### PR TITLE
allowing --ld-window-r2 flag for --r

### DIFF
--- a/1.9/plink.c
+++ b/1.9/plink.c
@@ -10801,9 +10801,6 @@ int32_t main(int32_t argc, char** argv) {
 	}
 	if (*argptr2 == '2') {
           ld_info.modifier |= LD_R2;
-	} else if (ld_info.window_r2 != 0.2) {
-	  logerrprint("Error: --ld-window-r2 flag cannot be used with --r.\n");
-          goto main_ret_INVALID_CMDLINE_A;
 	}
 	if (matrix_flag_state) {
 	  matrix_flag_state = 2;

--- a/1.9/plink_ld.c
+++ b/1.9/plink_ld.c
@@ -2711,7 +2711,7 @@ uint32_t ld_regular_emitn(uint32_t overflow_ct, unsigned char* readbuf) {
     while (block_idx2 < block_end2) {
       next_unset_ul_unsafe_ck(marker_exclude, &marker_uidx2);
       dxx = *dptr++;
-      if ((!is_r2) || (fabs(dxx) >= window_r2)) {
+      if (fabs(dxx) >= window_r2) {
 	sptr_cur = memcpya(sptr_cur, g_textbuf, prefix_len);
 	if (is_inter_chr) {
 	  if (marker_uidx2 >= chrom_end2) {
@@ -5863,6 +5863,8 @@ int32_t ld_report_regular(pthread_t* threads, Ld_info* ldip, FILE* bedfile, uint
   g_ld_is_first_block = (!parallel_idx);
   if (g_ld_is_r2) {
     g_ld_window_r2 = ldip->window_r2;
+  } else {
+    g_ld_window_r2 = sqrt(ldip->window_r2);
   }
   if (ld_modifier & LD_DX) {
     // this is more like --fast-epistasis under the hood, since it requires the


### PR DESCRIPTION
For some work that I'm doing it is necessary to calculate a large number of tag SNPs using the `--r` function, but this is problematic as it is slow and creates a huge output as there is no flag to limit the output based on magnitude of LD.

In this commit I have simply allowed `--ld-window-r2` to be used with both `--r` and `--r2`, which extends the behaviour to how it was previously when it only worked for `--r2`. The interpretation to the user is that if the supply the `--r --ld-window-r2 <val>` then the threshold will be set at `abs(r) > sqrt(<val>))`.

Previously it seems the default behaviour was to print every LD value for `--r`. Now the default will be the same as the default for `--r2` which is to only print anything with `r2 > 0.2`.