### PR TITLE
enable building on non-x86 systems

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "2.0/include/simde"]
+	path = 2.0/include/simde
+	url = https://github.com/nemequ/simde-no-tests

--- a/2.0/Makefile
+++ b/2.0/Makefile
@@ -6,7 +6,7 @@
 
 # Does not currently support -DCPU_CHECK_...
 
-BASEFLAGS=-g -mavx2 -mbmi -mbmi2 -mlzcnt -DZSTD_MULTITHREAD
+BASEFLAGS=-g -DZSTD_MULTITHREAD
 # BASEFLAGS=-g -msse4.2 -DZSTD_MULTITHREAD
 # BASEFLAGS=-g -DZSTD_MULTITHREAD
 

--- a/2.0/build_dynamic/Makefile
+++ b/2.0/build_dynamic/Makefile
@@ -143,17 +143,19 @@ ifdef FORCE_32BIT
   CXXFLAGS += -Wno-sign-compare
 endif
 
-all: plink2 pgen_compress
+SFX ?= ""
 
-plink2: $(CSRC2) $(ZCSRC2) $(CCSRC2) ../plink2_cpu.cc
+all: plink2$(SFX) pgen_compress
+
+plink2$(SFX): $(CSRC2) $(ZCSRC2) $(CCSRC2) ../plink2_cpu.cc
 	gcc $(CFLAGS) $(CSRC2) -c
 	$(SKIP_STATIC_ZSTD) gcc $(ZCFLAGS) $(ZCSRC2) -c
 	g++ $(CXXFLAGS) $(CCSRC2) -c
 	g++ $(CPUCHECK_FLAGS) ../plink2_cpu.cc -c
-	g++ $(OBJ2) plink2_cpu.o $(ARCH32) -o plink2 $(BLASFLAGS) $(LINKFLAGS)
+	g++ $(OBJ2) plink2_cpu.o $(ARCH32) -o $@ $(BLASFLAGS) $(LINKFLAGS)
 
-pgen_compress: $(PGCSRC2)
-	g++ $(CXXFLAGS) $(PGCSRC2) -o pgen_compress
+pgen_compress$(SFX): $(PGCSRC2)
+	g++ $(CXXFLAGS) $(PGCSRC2) -o $@
 
 .PHONY: clean
 clean:

--- a/2.0/include/SFMT.h
+++ b/2.0/include/SFMT.h
@@ -129,7 +129,8 @@ extern "C" {
   128-bit SIMD like data type for standard C
   ------------------------------------------*/
 #ifdef __LP64__
-  #include <emmintrin.h>
+  #define SIMDE_ENABLE_NATIVE_ALIASES
+  #include <simde/x86/sse2.h>
 
 /** 128-bit data structure */
 union W128_T {

--- a/2.0/include/plink2_base.h
+++ b/2.0/include/plink2_base.h
@@ -134,14 +134,8 @@
 #endif
 
 #ifdef __LP64__
-#  ifndef __SSE2__
-// possible todo: remove this requirement, the 32-bit VecW-using code does most
-// of what we need.  But little point in doing this before we have e.g. an
-// ARM-based machine to test with that scientists would plausibly want to run
-// plink2 on.
-#    error "64-bit builds currently require SSE2.  Try producing a 32-bit build instead."
-#  endif
-#  include <emmintrin.h>
+#  define SIMDE_ENABLE_NATIVE_ALIASES
+#  include <simde/x86/sse2.h>
 #  ifdef __SSE4_2__
 #    define USE_SSE42
 #    include <smmintrin.h>

--- a/2.0/plink2.cc
+++ b/2.0/plink2.cc
@@ -3071,7 +3071,7 @@ int main(int argc, char** argv) {
 #ifdef __APPLE__
   fesetenv(FE_DFL_DISABLE_SSE_DENORMS_ENV);
 #else
-#  ifdef __LP64__
+#  if defined __LP64__ && defined __x86_64__
   _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
 #  endif
 #endif

--- a/2.0/plink2_glm.cc
+++ b/2.0/plink2_glm.cc
@@ -19,6 +19,9 @@
 #include "plink2_glm.h"
 #include "plink2_matrix.h"
 
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include <simde/x86/sse2.h>
+
 #ifdef __cplusplus
 namespace plink2 {
 #endif


### PR DESCRIPTION
Hello again. This is another patch from the Debian package of plink2. It enables building on non-x86 architectures link arm64, ppc64el, s390x, and more: https://buildd.debian.org/status/package.php?p=plink2

This also allows us to compile plink on x86 systems without advanced SIMD usage, as that is required by the Debian x86 64 and 32 bit architecture baselines. On x86 we make several plink2 binaries using the `SFX` shown below. At runtime a dispatcher script selects the most capable binary for the user's CPU.

You can see our compile recipe at https://salsa.debian.org/med-team/plink2/-/blob/master/debian/rules#L36 and the dispatcher script at https://salsa.debian.org/med-team/plink2/-/blob/master/debian/bin/simd-dispatch

If a CPU dispatcher was integrated into plink2 then this external script would not be necessary.

Please let me know what I can do to improve this PR so it gets merged. Thanks!