### PR TITLE
Portable __m128i and __m256i setting

### DIFF
--- a/2.0/plink2_glm.cc
+++ b/2.0/plink2_glm.cc
@@ -2171,20 +2171,20 @@ const uint32_t kFloatExpLookupInt[]
 #  ifdef FVEC_32
 static inline VecF fmath_exp_ps(VecF xxv) {
   __m256 xx = R_CAST(__m256, xxv);
-  const __m256i mask7ff = {0x7fffffff7fffffffLLU, 0x7fffffff7fffffffLLU, 0x7fffffff7fffffffLLU, 0x7fffffff7fffffffLLU};
+  const __m256i mask7ff = _mm256_set1_epi32(UINT32_C(0x7fffffff));
   // 88
-  const __m256i max_x = {0x42b0000042b00000LLU, 0x42b0000042b00000LLU, 0x42b0000042b00000LLU, 0x42b0000042b00000LLU};
+  const __m256i max_x = _mm256_set1_epi32(UINT32_C(0x42b00000));
   // -88
   // more sensible 0xc2b00000... not used here due to "narrowing conversion"
   // warning
-  const __m256i min_x = {-0x3d4fffff3d500000LL, -0x3d4fffff3d500000LL, -0x3d4fffff3d500000LL, -0x3d4fffff3d500000LL};
+  const __m256i min_x = _mm256_set1_epi64x(INT64_C(-0x3d4fffff3d500000));
   // 2^10 / log(2)
-  const __m256i const_aa = {0x44b8aa3b44b8aa3bLLU, 0x44b8aa3b44b8aa3bLLU, 0x44b8aa3b44b8aa3bLLU, 0x44b8aa3b44b8aa3bLLU};
+  const __m256i const_aa = _mm256_set1_epi32(UINT32_C(0x44b8aa3b));
   // log(2) / 2^10
-  const __m256i const_bb = {0x3a3172183a317218LLU, 0x3a3172183a317218LLU, 0x3a3172183a317218LLU, 0x3a3172183a317218LLU};
-  const __m256i f1 = {0x3f8000003f800000LLU, 0x3f8000003f800000LLU, 0x3f8000003f800000LLU, 0x3f8000003f800000LLU};
-  const __m256i mask_s = {0x3ff000003ffLLU, 0x3ff000003ffLLU, 0x3ff000003ffLLU, 0x3ff000003ffLLU};
-  const __m256i i127s = {0x1fc000001fc00LLU, 0x1fc000001fc00LLU, 0x1fc000001fc00LLU, 0x1fc000001fc00LLU};
+  const __m256i const_bb = _mm256_set1_epi32(UINT64_C(0x3a317218));
+  const __m256i f1 = _mm256_set1_epi32(UINT32_C(0x3f800000));
+  const __m256i mask_s = _mm256_set1_epi32(UINT64_C(0x000003ff));
+  const __m256i i127s = _mm256_set1_epi32(UINT32_C(0x0001fc00));
   const __m256i limit = _mm256_castps_si256(_mm256_and_ps(xx, R_CAST(__m256, mask7ff)));
   const int32_t over = _mm256_movemask_epi8(_mm256_cmpgt_epi32(limit, max_x));
   if (over) {

--- a/2.0/plink2_glm.cc
+++ b/2.0/plink2_glm.cc
@@ -2291,22 +2291,22 @@ const float* const kFloatExpLookup = R_CAST(const float*, kFloatExpLookupInt);
 
 static inline VecF fmath_exp_ps(VecF xxv) {
   __m128 xx = xxv;
-  const __m128i mask7ff = {0x7fffffff7fffffffLLU, 0x7fffffff7fffffffLLU};
+  const __m128i mask7ff = _mm_set1_epi32(UINT32_C(0x7fffffff));
 
   // 88
-  const __m128i max_x = {0x42b0000042b00000LLU, 0x42b0000042b00000LLU};
+  const __m128i max_x = _mm_set1_epi32(UINT32_C(0x42b00000));
   // -88
   // more sensible 0xc2b00000... not used here due to "narrowing conversion"
   // warning
-  const __m128i min_x = {-0x3d4fffff3d500000LL, -0x3d4fffff3d500000LL};
+  const __m128i min_x = _mm_set1_epi64x(INT64_C(-0x3d4fffff3d500000));
   // 2^10 / log(2)
-  const __m128i const_aa = {0x44b8aa3b44b8aa3bLLU, 0x44b8aa3b44b8aa3bLLU};
+  const __m128i const_aa = _mm_set1_epi32(UINT32_C(0x44b8aa3b));
   // log(2) / 2^10
-  const __m128i const_bb = {0x3a3172183a317218LLU, 0x3a3172183a317218LLU};
+  const __m128i const_bb = _mm_set1_epi32(UINT32_C(0x3a317218));
 
-  const __m128i f1 = {0x3f8000003f800000LLU, 0x3f8000003f800000LLU};
-  const __m128i mask_s = {0x3ff000003ffLLU, 0x3ff000003ffLLU};
-  const __m128i i127s = {0x1fc000001fc00LLU, 0x1fc000001fc00LLU};
+  const __m128i f1 = _mm_set1_epi32(UINT32_C(0x3f800000));
+  const __m128i mask_s = _mm_set1_epi64x(UINT64_C(0x3ff000003ff));
+  const __m128i i127s = _mm_set1_epi32(UINT32_C(0x0001fc00));
   const __m128i limit = _mm_castps_si128(_mm_and_ps(xx, R_CAST(__m128, mask7ff)));
   const int32_t over = _mm_movemask_epi8(_mm_cmpgt_epi32(limit, max_x));
   if (over) {

--- a/2.0/plink2_ld.cc
+++ b/2.0/plink2_ld.cc
@@ -2157,11 +2157,11 @@ static_assert(sizeof(Dosage) == 2, "plink2_ld dosage-handling routines must be u
 void FillDosageUhet(const Dosage* dosage_vec, uint32_t dosagev_ct, Dosage* dosage_uhet) {
   const __m256i* dosage_vvec_iter = R_CAST(const __m256i*, dosage_vec);
 #    if defined(__APPLE__) && ((!defined(__cplusplus)) || (__cplusplus < 201103L))
-  const __m256i all_n32768 = {0x8000800080008000LLU, 0x8000800080008000LLU, 0x8000800080008000LLU, 0x8000800080008000LLU};
-  const __m256i all_n16384 = {0xc000c000c000c000LLU, 0xc000c000c000c000LLU, 0xc000c000c000c000LLU, 0xc000c000c000c000LLU};
+  const __m256i all_n32768 = _mm256_set1_epi16(UINT16_C(0x8000));
+  const __m256i all_n16384 = _mm256_set1_epi16(UINT16_C(0xc000));
 #    else
-  const __m256i all_n32768 = {-0x7fff7fff7fff8000LL, -0x7fff7fff7fff8000LL, -0x7fff7fff7fff8000LL, -0x7fff7fff7fff8000LL};
-  const __m256i all_n16384 = {-0x3fff3fff3fff4000LL, -0x3fff3fff3fff4000LL, -0x3fff3fff3fff4000LL, -0x3fff3fff3fff4000LL};
+  const __m256i all_n32768 = _mm256_set1_epi64x(INT64_C(-0x7fff7fff7fff8000));
+  const __m256i all_n16384 = _mm256_set1_epi64x(INT64_C(-0x3fff3fff3fff4000));
 #    endif
   const __m256i all0 = _mm256_setzero_si256();
   const __m256i all1 = _mm256_cmpeq_epi16(all0, all0);
@@ -2195,7 +2195,7 @@ void FillDosageUhet(const Dosage* dosage_vec, uint32_t dosagev_ct, Dosage* dosag
 uint64_t DenseDosageSum(const Dosage* dosage_vec, uint32_t vec_ct) {
   // end of dosage_vec assumed to be missing-padded (0-padded also ok)
   const __m256i* dosage_vvec_iter = R_CAST(const __m256i*, dosage_vec);
-  const __m256i m16 = {kMask0000FFFF, kMask0000FFFF, kMask0000FFFF, kMask0000FFFF};
+  const __m256i m16 = _mm256_set1_epi64x(kMask0000FFFF);
   const __m256i all1 = _mm256_cmpeq_epi16(m16, m16);
   uint64_t sum = 0;
   for (uint32_t vecs_left = vec_ct; ; ) {
@@ -2231,7 +2231,7 @@ uint64_t DenseDosageSumSubset(const Dosage* dosage_vec, const Dosage* dosage_mas
   // end of dosage_vec assumed to be missing-padded (0-padded also ok)
   const __m256i* dosage_vvec_iter = R_CAST(const __m256i*, dosage_vec);
   const __m256i* dosage_mask_vvec_iter = R_CAST(const __m256i*, dosage_mask_vec);
-  const __m256i m16 = {kMask0000FFFF, kMask0000FFFF, kMask0000FFFF, kMask0000FFFF};
+  const __m256i m16 = _mm256_set1_epi64x(kMask0000FFFF);
   const __m256i all1 = _mm256_cmpeq_epi16(m16, m16);
   uint64_t sum = 0;
   for (uint32_t vecs_left = vec_ct; ; ) {
@@ -2267,7 +2267,7 @@ uint64_t DenseDosageSumSubset(const Dosage* dosage_vec, const Dosage* dosage_mas
 uint64_t DosageUnsignedDotprod(const Dosage* dosage_vec0, const Dosage* dosage_vec1, uint32_t vec_ct) {
   const __m256i* dosage_vvec0_iter = R_CAST(const __m256i*, dosage_vec0);
   const __m256i* dosage_vvec1_iter = R_CAST(const __m256i*, dosage_vec1);
-  const __m256i m16 = {kMask0000FFFF, kMask0000FFFF, kMask0000FFFF, kMask0000FFFF};
+  const __m256i m16 = _mm256_set1_epi64x(kMask0000FFFF);
   const __m256i all1 = _mm256_cmpeq_epi16(m16, m16);
   uint64_t dotprod = 0;
   for (uint32_t vecs_left = vec_ct; ; ) {
@@ -2312,7 +2312,7 @@ uint64_t DosageUnsignedDotprod(const Dosage* dosage_vec0, const Dosage* dosage_v
 uint64_t DosageUnsignedNomissDotprod(const Dosage* dosage_vec0, const Dosage* dosage_vec1, uint32_t vec_ct) {
   const __m256i* dosage_vvec0_iter = R_CAST(const __m256i*, dosage_vec0);
   const __m256i* dosage_vvec1_iter = R_CAST(const __m256i*, dosage_vec1);
-  const __m256i m16 = {kMask0000FFFF, kMask0000FFFF, kMask0000FFFF, kMask0000FFFF};
+  const __m256i m16 = _mm256_set1_epi64x(kMask0000FFFF);
   uint64_t dotprod = 0;
   for (uint32_t vecs_left = vec_ct; ; ) {
     __m256i dotprod_lo = _mm256_setzero_si256();
@@ -2350,8 +2350,8 @@ uint64_t DosageUnsignedNomissDotprod(const Dosage* dosage_vec0, const Dosage* do
 int64_t DosageSignedDotprod(const SDosage* dphase_delta0, const SDosage* dphase_delta1, uint32_t vec_ct) {
   const __m256i* dphase_delta0_iter = R_CAST(const __m256i*, dphase_delta0);
   const __m256i* dphase_delta1_iter = R_CAST(const __m256i*, dphase_delta1);
-  const __m256i m16 = {kMask0000FFFF, kMask0000FFFF, kMask0000FFFF, kMask0000FFFF};
-  const __m256i all_4096 = {0x1000100010001000LLU, 0x1000100010001000LLU, 0x1000100010001000LLU, 0x1000100010001000LLU};
+  const __m256i m16 = _mm256_set1_epi64x(kMask0000FFFF);
+  const __m256i all_4096 = _mm256_set1_epi16(UINT16_C(0x1000));
   uint64_t dotprod = 0;
   for (uint32_t vecs_left = vec_ct; ; ) {
     __m256i dotprod_lo = _mm256_setzero_si256();

--- a/2.0/plink2_ld.cc
+++ b/2.0/plink2_ld.cc
@@ -2400,11 +2400,11 @@ int64_t DosageSignedDotprod(const SDosage* dphase_delta0, const SDosage* dphase_
 void FillDosageUhet(const Dosage* dosage_vec, uint32_t dosagev_ct, Dosage* dosage_uhet) {
   const __m128i* dosage_vvec_iter = R_CAST(const __m128i*, dosage_vec);
 #    if defined(__APPLE__) && ((!defined(__cplusplus)) || (__cplusplus < 201103L))
-  const __m128i all_n32768 = {0x8000800080008000LLU, 0x8000800080008000LLU};
-  const __m128i all_n16384 = {0xc000c000c000c000LLU, 0xc000c000c000c000LLU};
+  const __m128i all_n32768 = _mm_set1_epi16(UINT16_C(0x8000));
+  const __m128i all_n16384 = _mm_set1_epi16(UINT16_C(0xc000));
 #    else
-  const __m128i all_n32768 = {-0x7fff7fff7fff8000LL, -0x7fff7fff7fff8000LL};
-  const __m128i all_n16384 = {-0x3fff3fff3fff4000LL, -0x3fff3fff3fff4000LL};
+  const __m128i all_n32768 = _mm_set1_epi64x(INT64_C(-0x7fff7fff7fff8000));
+  const __m128i all_n16384 = _mm_set1_epi64x(INT64_C(-0x3fff3fff3fff4000));
 #    endif
   const __m128i all0 = _mm_setzero_si128();
   const __m128i all1 = _mm_cmpeq_epi16(all0, all0);
@@ -2435,7 +2435,7 @@ void FillDosageUhet(const Dosage* dosage_vec, uint32_t dosagev_ct, Dosage* dosag
 uint64_t DenseDosageSum(const Dosage* dosage_vec, uint32_t vec_ct) {
   // end of dosage_vec assumed to be missing-padded (0-padded also ok)
   const __m128i* dosage_vvec_iter = R_CAST(const __m128i*, dosage_vec);
-  const __m128i m16 = {kMask0000FFFF, kMask0000FFFF};
+  const __m128i m16 = _mm_set1_epi64x(kMask0000FFFF);
   const __m128i all1 = _mm_cmpeq_epi16(m16, m16);
   uint64_t sum = 0;
   for (uint32_t vecs_left = vec_ct; ; ) {
@@ -2471,7 +2471,7 @@ uint64_t DenseDosageSumSubset(const Dosage* dosage_vec, const Dosage* dosage_mas
   // end of dosage_vec assumed to be missing-padded (0-padded also ok)
   const __m128i* dosage_vvec_iter = R_CAST(const __m128i*, dosage_vec);
   const __m128i* dosage_mask_vvec_iter = R_CAST(const __m128i*, dosage_mask_vec);
-  const __m128i m16 = {kMask0000FFFF, kMask0000FFFF};
+  const __m128i m16 = _mm_set1_epi64x(kMask0000FFFF);
   const __m128i all1 = _mm_cmpeq_epi16(m16, m16);
   uint64_t sum = 0;
   for (uint32_t vecs_left = vec_ct; ; ) {
@@ -2507,7 +2507,7 @@ uint64_t DenseDosageSumSubset(const Dosage* dosage_vec, const Dosage* dosage_mas
 uint64_t DosageUnsignedDotprod(const Dosage* dosage_vec0, const Dosage* dosage_vec1, uint32_t vec_ct) {
   const __m128i* dosage_vvec0_iter = R_CAST(const __m128i*, dosage_vec0);
   const __m128i* dosage_vvec1_iter = R_CAST(const __m128i*, dosage_vec1);
-  const __m128i m16 = {kMask0000FFFF, kMask0000FFFF};
+  const __m128i m16 = _mm_set1_epi64x(kMask0000FFFF);
   const __m128i all1 = _mm_cmpeq_epi16(m16, m16);
   uint64_t dotprod = 0;
   for (uint32_t vecs_left = vec_ct; ; ) {
@@ -2550,7 +2550,7 @@ uint64_t DosageUnsignedDotprod(const Dosage* dosage_vec0, const Dosage* dosage_v
 uint64_t DosageUnsignedNomissDotprod(const Dosage* dosage_vec0, const Dosage* dosage_vec1, uint32_t vec_ct) {
   const __m128i* dosage_vvec0_iter = R_CAST(const __m128i*, dosage_vec0);
   const __m128i* dosage_vvec1_iter = R_CAST(const __m128i*, dosage_vec1);
-  const __m128i m16 = {kMask0000FFFF, kMask0000FFFF};
+  const __m128i m16 = _mm_set1_epi64x(kMask0000FFFF);
   uint64_t dotprod = 0;
   for (uint32_t vecs_left = vec_ct; ; ) {
     __m128i dotprod_lo = _mm_setzero_si128();
@@ -2588,8 +2588,8 @@ uint64_t DosageUnsignedNomissDotprod(const Dosage* dosage_vec0, const Dosage* do
 int64_t DosageSignedDotprod(const SDosage* dphase_delta0, const SDosage* dphase_delta1, uint32_t vec_ct) {
   const __m128i* dphase_delta0_iter = R_CAST(const __m128i*, dphase_delta0);
   const __m128i* dphase_delta1_iter = R_CAST(const __m128i*, dphase_delta1);
-  const __m128i m16 = {kMask0000FFFF, kMask0000FFFF};
-  const __m128i all_4096 = {0x1000100010001000LLU, 0x1000100010001000LLU};
+  const __m128i m16 = _mm_set1_epi64x(kMask0000FFFF);
+  const __m128i all_4096 = _mm_set1_epi16(UINT16_C(0x1000));
   uint64_t dotprod = 0;
   for (uint32_t vecs_left = vec_ct; ; ) {
     __m128i dotprod_lo = _mm_setzero_si128();


### PR DESCRIPTION
Setting with `{}` is a gcc-ism and is non-standard