### PR TITLE
Fixes maybe-uninitialized warning thown in line 3392 (now 3399).

### DIFF
--- a/1.9/plink_ld.c
+++ b/1.9/plink_ld.c
@@ -3233,7 +3233,14 @@ void fepi_counts_to_joint_effects_stats(uint32_t group_ct, uint32_t* counts, dou
   uint32_t uii;
   uint32_t ujj;
   uint32_t ukk;
-  tot_inv_v[0] = 0.0;  // gcc7 maybe-uninitialized warning
+  /* As of 2021-04-04, group_ct only takes 1 or 2., but the compiler is failing to notice, generating 'maybe-uninitialized' warnings.
+   * This assertion makes the compiler aware, thereby removing those maybe-uninitialized' warnings.*/
+  if (group_ct != 1 && group_ct != 2) {
+    /* Shouldn't be here. */
+    logerrprint("Error: Unexpected value of 'group_co'.\n");
+    exit(1);
+  }
+
   dptr = dcounts;
   if (counts[0] && counts[1] && counts[2] && counts[3] && counts[4] && counts[5] && counts[6] && counts[7] && counts[8] && ((group_ct == 1) || (counts[9] && counts[10] && counts[11] && counts[12] && counts[13] && counts[14] && counts[15] && counts[16] && counts[17]))) {
     for (uii = 0; uii < group_ct; uii++) {


### PR DESCRIPTION
The warning was thrown at line 3392 of the original code for lambda_or_mu[0] and was caused by the compiler not noticing that group_ct can be either 1 or 2. This same issue caused the warning about tot_inv_v[0] that has been previously fixed by initializing it to zero. 
The issue is here resolved by adding an 'if' clause, because it seemed the least intrusive. The initialization of tot_inv_v[0] to zero was removed because the fix made it redundant.
Tested on both centos7 with devtoolset-7 (gcc 7.3.1) and fedora33 with gcc 10.2.1.