### PR TITLE
GitHub Actions checks if `pgenlib` can be installed

### DIFF
--- a/.github/workflows/can_install_pgenlib_package.yaml
+++ b/.github/workflows/can_install_pgenlib_package.yaml
@@ -1,4 +1,10 @@
-# Checks if the pgenlib R package can be installed
+# Checks if the pgenlib R package can be installed by a user,
+# when installing pgenlibr using:
+#
+# ```
+# remotes::install_github("chrchang/plink-ng/2.0/pgenlibr")
+# ```
+#
 
 on:
   push:

--- a/.github/workflows/can_install_pgenlib_package.yaml
+++ b/.github/workflows/can_install_pgenlib_package.yaml
@@ -1,4 +1,9 @@
 # Checks if the pgenlib R package can be installed
+
+on:
+  push:
+  pull_request:
+
 name: can_install_pgenlib_package
 
 jobs:

--- a/.github/workflows/can_install_pgenlib_package.yaml
+++ b/.github/workflows/can_install_pgenlib_package.yaml
@@ -1,0 +1,23 @@
+# Checks if the pgenlib R package can be installed
+name: can_install_pgenlib_package
+
+jobs:
+  can_install_pgenlib_package:
+
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+
+      # Install R
+      - uses: r-lib/actions/setup-r@v1
+
+      # Prequisite for using the 'remotes' R package
+      - name: Install libcurl4-openssl-dev
+        run: sudo apt install -qq libcurl4-openssl-dev
+
+      - name: Install pgenlibr
+        run: |
+          install.packages("remotes")
+          remotes::install_github("chrchang/plink-ng/2.0/pgenlibr")
+        shell: Rscript {0}


### PR DESCRIPTION
Hi @chrchang,

Following #204. in which I submitted a bug report that `pgenlib` could not be installed, here is a GitHub Actions that helps to prevent this in the future: in the default GitHub Actions settings, the owner of the repo will receive an email if the build breaks (of course, this can be turned off). 

I kept this PR minimal, e.g. I did not add a GHA build badge [1], but volunteer to add that as well.

Thanks for allowing PLINK to show off its quality and cheers, Richel

 * [1] An example build badge (just the image, it has no clickable link): 

![build_badge](https://user-images.githubusercontent.com/2098230/149133009-944fe891-20f3-43c2-aec2-b78b8f9aec18.png)
