### PR TITLE
Allow Plink 1.9 to compile & run on Apple Silicon 

### DIFF
--- a/1.9/Makefile
+++ b/1.9/Makefile
@@ -24,6 +24,8 @@ else
   endif
 endif
 
+ARCH := $(shell uname -p)
+
 # Allow these to be overridden by make arguments or env variables, so people
 # don't have to edit the Makefile to build in a different environment.
 BIN ?=		plink
@@ -47,7 +49,11 @@ ifeq ($(SYS), MAC)
   CXXFLAGS += $(MACFLAGS)
   BLASFLAGS ?= -framework Accelerate
   LDFLAGS ?= -ldl
-  ZLIB ?= -L. ../zlib-1.2.11/libz-64.a
+  ifeq ($(ARCH), arm)
+    ZLIB ?= -L. ../zlib-1.2.11/libz.a
+  else
+    ZLIB ?= -L. ../zlib-1.2.11/libz-64.a
+  endif
 endif
 
 ifeq ($(SYS), WIN)

--- a/1.9/Makefile
+++ b/1.9/Makefile
@@ -49,11 +49,7 @@ ifeq ($(SYS), MAC)
   CXXFLAGS += $(MACFLAGS)
   BLASFLAGS ?= -framework Accelerate
   LDFLAGS ?= -ldl
-  ifeq ($(ARCH), arm)
-    ZLIB ?= -L. ../zlib-1.2.11/libz.a
-  else
-    ZLIB ?= -L. ../zlib-1.2.11/libz-64.a
-  endif
+  ZLIB ?= -L. ../zlib-1.2.11/libz.a
 endif
 
 ifeq ($(SYS), WIN)

--- a/1.9/Makefile
+++ b/1.9/Makefile
@@ -24,8 +24,6 @@ else
   endif
 endif
 
-ARCH := $(shell uname -p)
-
 # Allow these to be overridden by make arguments or env variables, so people
 # don't have to edit the Makefile to build in a different environment.
 BIN ?=		plink


### PR DESCRIPTION
Add conditional logic to link to the correct static libz on apple silicon arm64 CPU on Mac OS.

As documented [here](https://github.com/chrchang/plink-ng/issues/162), this is the minimum changeset necessary to allow Plink 1.9 to work with Apple Silicon.

It looks like 2.0 will take a bit more work.