### PR TITLE
Fix Plink2 build on Apple Silicon MacOS: Call NEON SIMD instructions with constants.

### DIFF
--- a/2.0/include/plink2_base.h
+++ b/2.0/include/plink2_base.h
@@ -767,17 +767,19 @@ HEADER_INLINE VecW vecw_srli(VecW vv, uint32_t ct) {
   return R_CAST(VecW, _mm256_srli_epi64(R_CAST(__m256i, vv), ct));
 }
 
-HEADER_INLINE VecW vecw_slli(VecW vv, uint32_t ct) {
-  return R_CAST(VecW, _mm256_slli_epi64(R_CAST(__m256i, vv), ct));
-}
+#define vecw_slli(vv, ct) R_CAST(VecW, _mm256_slli_epi64(R_CAST(__m256i, vv), ct))
 
-HEADER_INLINE VecU32 vecu32_srli(VecU32 vv, uint32_t ct) {
-  return R_CAST(VecU32, _mm256_srli_epi32(R_CAST(__m256i, vv), ct));
-}
+// HEADER_INLINE VecW vecw_slli(VecW vv, uint32_t ct) {
+//   return R_CAST(VecW, _mm256_slli_epi64(R_CAST(__m256i, vv), ct));
+// }
 
-HEADER_INLINE VecU32 vecu32_slli(VecU32 vv, uint32_t ct) {
-  return R_CAST(VecU32, _mm256_slli_epi32(R_CAST(__m256i, vv), ct));
-}
+// HEADER_INLINE VecU32 vecu32_srli(VecU32 vv, uint32_t ct) {
+//   return R_CAST(VecU32, _mm256_srli_epi32(R_CAST(__m256i, vv), ct));
+// }
+
+// HEADER_INLINE VecU32 vecu32_slli(VecU32 vv, uint32_t ct) {
+//   return R_CAST(VecU32, _mm256_slli_epi32(R_CAST(__m256i, vv), ct));
+// }
 
 HEADER_INLINE VecU16 vecu16_srli(VecU16 vv, uint32_t ct) {
   return R_CAST(VecU16, _mm256_srli_epi16(R_CAST(__m256i, vv), ct));
@@ -1104,29 +1106,41 @@ HEADER_INLINE VecI8 veci8_setzero() {
   return R_CAST(VecI8, _mm_setzero_si128());
 }
 
-HEADER_INLINE VecW vecw_srli(VecW vv, uint32_t ct) {
-  return R_CAST(VecW, _mm_srli_epi64(R_CAST(__m128i, vv), ct));
-}
+#define vecw_srli(vv, ct) R_CAST(VecW, _mm_srli_epi64(R_CAST(__m128i, vv), ct))
 
-HEADER_INLINE VecW vecw_slli(VecW vv, uint32_t ct) {
-  return R_CAST(VecW, _mm_slli_epi64(R_CAST(__m128i, vv), ct));
-}
+// HEADER_INLINE VecW vecw_srli(VecW vv, const uint8_t& ct) {
+//   return R_CAST(VecW, _mm_srli_epi64(R_CAST(__m128i, vv), ct));
+// }
 
-HEADER_INLINE VecU32 vecu32_srli(VecU32 vv, uint32_t ct) {
-  return R_CAST(VecU32, _mm_srli_epi32(R_CAST(__m128i, vv), ct));
-}
+#define vecw_slli(vv, ct) R_CAST(VecW, _mm_slli_epi64(R_CAST(__m128i, vv), ct))
 
-HEADER_INLINE VecU32 vecu32_slli(VecU32 vv, uint32_t ct) {
-  return R_CAST(VecU32, _mm_slli_epi32(R_CAST(__m128i, vv), ct));
-}
+// HEADER_INLINE VecW vecw_slli(VecW vv, const uint8_t& ct) {
+//   return R_CAST(VecW, _mm_slli_epi64(R_CAST(__m128i, vv), ct));
+// }
 
-HEADER_INLINE VecU16 vecu16_srli(VecU16 vv, uint32_t ct) {
-  return R_CAST(VecU16, _mm_srli_epi16(R_CAST(__m128i, vv), ct));
-}
+#define vecu32_srli(vv, ct) R_CAST(VecU32, _mm_srli_epi32(R_CAST(__m128i, vv), ct))
 
-HEADER_INLINE VecU16 vecu16_slli(VecU16 vv, uint32_t ct) {
-  return R_CAST(VecU16, _mm_slli_epi16(R_CAST(__m128i, vv), ct));
-}
+// HEADER_INLINE VecU32 vecu32_srli(VecU32 vv, const uint8_t& ct) {
+//   return R_CAST(VecU32, _mm_srli_epi32(R_CAST(__m128i, vv), ct));
+// }
+
+#define vecu32_slli(vv, ct) R_CAST(VecU32, _mm_slli_epi32(R_CAST(__m128i, vv), ct))
+
+// HEADER_INLINE VecU32 vecu32_slli(VecU32 vv, const uint8_t& ct) {
+//   return R_CAST(VecU32, _mm_slli_epi32(R_CAST(__m128i, vv), ct));
+// }
+
+#define vecu16_srli(vv, ct) R_CAST(VecU16, _mm_srli_epi16(R_CAST(__m128i, vv), ct))
+
+// HEADER_INLINE VecU16 vecu16_srli(VecU16 vv, const uint8_t& ct) {
+//   return R_CAST(VecU16, _mm_srli_epi16(R_CAST(__m128i, vv), ct));
+// }
+
+#define vecu16_slli(vv, ct) R_CAST(VecU16, _mm_slli_epi16(R_CAST(__m128i, vv), ct))
+
+// HEADER_INLINE VecU16 vecu16_slli(VecU16 vv, const uint8_t& ct) {
+//   return R_CAST(VecU16, _mm_slli_epi16(R_CAST(__m128i, vv), ct));
+// }
 
 HEADER_INLINE VecW vecw_and_notfirst(VecW excl, VecW main) {
   return R_CAST(VecW, _mm_andnot_si128(R_CAST(__m128i, excl), R_CAST(__m128i, main)));

--- a/2.0/include/plink2_base.h
+++ b/2.0/include/plink2_base.h
@@ -767,7 +767,17 @@ HEADER_INLINE VecW vecw_srli(VecW vv, uint32_t ct) {
   return R_CAST(VecW, _mm256_srli_epi64(R_CAST(__m256i, vv), ct));
 }
 
-#define vecw_slli(vv, ct) R_CAST(VecW, _mm256_slli_epi64(R_CAST(__m256i, vv), ct))
+HEADER_INLINE VecW vecw_slli(VecW vv, uint32_t ct) {
+  return R_CAST(VecW, _mm256_slli_epi64(R_CAST(__m256i, vv), ct));
+}
+
+HEADER_INLINE VecU32 vecu32_srli(VecU32 vv, uint32_t ct) {
+  return R_CAST(VecU32, _mm256_srli_epi32(R_CAST(__m256i, vv), ct));
+}
+
+HEADER_INLINE VecU32 vecu32_slli(VecU32 vv, uint32_t ct) {
+  return R_CAST(VecU32, _mm256_slli_epi32(R_CAST(__m256i, vv), ct));
+}
 
 HEADER_INLINE VecU16 vecu16_srli(VecU16 vv, uint32_t ct) {
   return R_CAST(VecU16, _mm256_srli_epi16(R_CAST(__m256i, vv), ct));

--- a/2.0/include/plink2_base.h
+++ b/2.0/include/plink2_base.h
@@ -1096,39 +1096,15 @@ HEADER_INLINE VecI8 veci8_setzero() {
 
 #define vecw_srli(vv, ct) R_CAST(VecW, _mm_srli_epi64(R_CAST(__m128i, vv), ct))
 
-// HEADER_INLINE VecW vecw_srli(VecW vv, const uint8_t& ct) {
-//   return R_CAST(VecW, _mm_srli_epi64(R_CAST(__m128i, vv), ct));
-// }
-
 #define vecw_slli(vv, ct) R_CAST(VecW, _mm_slli_epi64(R_CAST(__m128i, vv), ct))
-
-// HEADER_INLINE VecW vecw_slli(VecW vv, const uint8_t& ct) {
-//   return R_CAST(VecW, _mm_slli_epi64(R_CAST(__m128i, vv), ct));
-// }
 
 #define vecu32_srli(vv, ct) R_CAST(VecU32, _mm_srli_epi32(R_CAST(__m128i, vv), ct))
 
-// HEADER_INLINE VecU32 vecu32_srli(VecU32 vv, const uint8_t& ct) {
-//   return R_CAST(VecU32, _mm_srli_epi32(R_CAST(__m128i, vv), ct));
-// }
-
 #define vecu32_slli(vv, ct) R_CAST(VecU32, _mm_slli_epi32(R_CAST(__m128i, vv), ct))
-
-// HEADER_INLINE VecU32 vecu32_slli(VecU32 vv, const uint8_t& ct) {
-//   return R_CAST(VecU32, _mm_slli_epi32(R_CAST(__m128i, vv), ct));
-// }
 
 #define vecu16_srli(vv, ct) R_CAST(VecU16, _mm_srli_epi16(R_CAST(__m128i, vv), ct))
 
-// HEADER_INLINE VecU16 vecu16_srli(VecU16 vv, const uint8_t& ct) {
-//   return R_CAST(VecU16, _mm_srli_epi16(R_CAST(__m128i, vv), ct));
-// }
-
 #define vecu16_slli(vv, ct) R_CAST(VecU16, _mm_slli_epi16(R_CAST(__m128i, vv), ct))
-
-// HEADER_INLINE VecU16 vecu16_slli(VecU16 vv, const uint8_t& ct) {
-//   return R_CAST(VecU16, _mm_slli_epi16(R_CAST(__m128i, vv), ct));
-// }
 
 HEADER_INLINE VecW vecw_and_notfirst(VecW excl, VecW main) {
   return R_CAST(VecW, _mm_andnot_si128(R_CAST(__m128i, excl), R_CAST(__m128i, main)));

--- a/2.0/include/plink2_base.h
+++ b/2.0/include/plink2_base.h
@@ -769,18 +769,6 @@ HEADER_INLINE VecW vecw_srli(VecW vv, uint32_t ct) {
 
 #define vecw_slli(vv, ct) R_CAST(VecW, _mm256_slli_epi64(R_CAST(__m256i, vv), ct))
 
-// HEADER_INLINE VecW vecw_slli(VecW vv, uint32_t ct) {
-//   return R_CAST(VecW, _mm256_slli_epi64(R_CAST(__m256i, vv), ct));
-// }
-
-// HEADER_INLINE VecU32 vecu32_srli(VecU32 vv, uint32_t ct) {
-//   return R_CAST(VecU32, _mm256_srli_epi32(R_CAST(__m256i, vv), ct));
-// }
-
-// HEADER_INLINE VecU32 vecu32_slli(VecU32 vv, uint32_t ct) {
-//   return R_CAST(VecU32, _mm256_slli_epi32(R_CAST(__m256i, vv), ct));
-// }
-
 HEADER_INLINE VecU16 vecu16_srli(VecU16 vv, uint32_t ct) {
   return R_CAST(VecU16, _mm256_srli_epi16(R_CAST(__m256i, vv), ct));
 }

--- a/2.0/include/plink2_bits.cc
+++ b/2.0/include/plink2_bits.cc
@@ -1974,7 +1974,11 @@ void TransposeBitblock64(const uintptr_t* read_iter, uintptr_t read_ul_stride, u
   Vec8thUint* write_iter_last = &(write_iter0[write_v8ui_stride * (row_ct_rem - 1)]);
   for (uint32_t vidx = 0; vidx != buf1_row_vecwidth; ++vidx) {
     VecW loader = buf1_read_iter[vidx];
-    loader = vecw_slli_lookup(loader, lshift);
+#   ifdef __x86_64__
+        loader = vecw_slli(loader, lshift);
+#   else
+        loader = vecw_slli_lookup(loader, lshift);
+#   endif // __x86_64__
     Vec8thUint* inner_write_iter = &(write_iter_last[vidx]);
     for (uint32_t uii = 0; uii != row_ct_rem; ++uii) {
       *inner_write_iter = vecw_movemask(loader);

--- a/2.0/plink2.cc
+++ b/2.0/plink2.cc
@@ -3121,8 +3121,8 @@ int main(int argc, char** argv) {
   using namespace plink2;
 #endif
 
-#ifdef __APPLE__
-  fesetenv(FE_DFL_DISABLE_SSE_DENORMS_ENV);
+#ifdef __APPLE__ && defined CPU_CHECK_AVX2
+  // fesetenv(FE_DFL_DISABLE_SSE_DENORMS_ENV);
 #else
 #  if defined __LP64__ && defined __x86_64__
   _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);

--- a/2.0/plink2.cc
+++ b/2.0/plink2.cc
@@ -3121,8 +3121,10 @@ int main(int argc, char** argv) {
   using namespace plink2;
 #endif
 
-#ifdef __APPLE__ && defined CPU_CHECK_AVX2
-  // fesetenv(FE_DFL_DISABLE_SSE_DENORMS_ENV);
+#ifdef __APPLE__
+  #if __x86_64__
+    fesetenv(FE_DFL_DISABLE_SSE_DENORMS_ENV);
+  #endif
 #else
 #  if defined __LP64__ && defined __x86_64__
   _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);

--- a/2.0/plink2_export.cc
+++ b/2.0/plink2_export.cc
@@ -6953,6 +6953,7 @@ void FixBcf64allelicGtHh(uint32_t sample_ct, char* __restrict gt_start) {
   for (uint32_t vidx = 0; vidx != fullvec_ct; ++vidx) {
     const VecU32 vv_orig = vecu32_loadu(&(gt_valias[vidx]));
     const VecU32 vv_lshift16 = vecu32_slli(vv_orig, 16);
+    // const VecU32 vv_lshift16 = R_CAST(VecU32, _mm_slli_epi32(R_CAST(__m128i, vv_orig), 16));
     const VecU32 vv_high_nophase = vv_orig & high_nophase_mask;
     const VecU32 vv_replace_mask = (vv_lshift16 == vv_high_nophase) & inv_m16;
     const VecU32 vv_final = vecu32_blendv(vv_orig, eov, vv_replace_mask);

--- a/2.0/plink2_export.cc
+++ b/2.0/plink2_export.cc
@@ -6953,7 +6953,6 @@ void FixBcf64allelicGtHh(uint32_t sample_ct, char* __restrict gt_start) {
   for (uint32_t vidx = 0; vidx != fullvec_ct; ++vidx) {
     const VecU32 vv_orig = vecu32_loadu(&(gt_valias[vidx]));
     const VecU32 vv_lshift16 = vecu32_slli(vv_orig, 16);
-    // const VecU32 vv_lshift16 = R_CAST(VecU32, _mm_slli_epi32(R_CAST(__m128i, vv_orig), 16));
     const VecU32 vv_high_nophase = vv_orig & high_nophase_mask;
     const VecU32 vv_replace_mask = (vv_lshift16 == vv_high_nophase) & inv_m16;
     const VecU32 vv_final = vecu32_blendv(vv_orig, eov, vv_replace_mask);


### PR DESCRIPTION
Replace the functions that wrap simde with macros, allowing them to work on ARM NEON. NEON requires that bit-shifting instructions are called with constant integers. This lets plink2.0 build on Apple Silicon on MacOS.

I changed the inline functions into macros, which is definitely more fragile and nastier to debug, but otherwise compilation would fail because the underlying NEON intrinsics could only be called with constant integers for the offset, meaning they can't be called from a function that takes runtime parameters. Where there were dynamic calls to these functions, I added a lookup table that will map to the function called with a compile-time constant. This doesn't feel great, but gets Plink2 running on Apple Silicon. I have not yet tested it extensively, but it runs.

I don't love this solution, but it seems to be what other projects are doing:
https://github.com/VectorCamp/vectorscan/pull/81/files#diff-1f738fe3ab986614e926b3ce01fcd42dbf3e8ccb79337931af69450f56319554R178

This would resolve https://github.com/chrchang/plink-ng/issues/162
