### PR TITLE
list `oldest-supported-numpy` as a build dependency

### DIFF
--- a/2.0/Python/pyproject.toml
+++ b/2.0/Python/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools","wheel","numpy>=1.19.0","Cython>=0.29.21"]
+requires = ["setuptools","wheel","oldest-supported-numpy","Cython>=0.29.21"]
 build-backend = "setuptools.build_meta"

--- a/2.0/Python/pyproject.toml
+++ b/2.0/Python/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools","wheel","oldest-supported-numpy","Cython>=0.29.21"]
+requires = ["setuptools","wheel","oldest-supported-numpy>=2022.8.16","Cython>=0.29.21"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Hi @chrchang,

Our team uses `pgenlib` and noticed an intermittent issue when installing it with `pip`. We've found that a binary incompatibility can occur when the version of `numpy` used to build `pgenlib` is newer than the version used when running `pgenlib`. We think the solution is to list the `oldest-supported-numpy` package as a build-time dependency instead of `numpy`.

See [the README for `oldest-supported-numpy`](https://pypi.org/project/oldest-supported-numpy/) and [the numpy documentation](https://numpy.org/doc/stable/user/depending_on_numpy.html#build-time-dependency) for more information on why this is advisable.

See https://github.com/CAST-genomics/haptools/issues/138 for our example instance of a binary incompatibility and a more detailed explanation of our problem in plain terms.

Thank you for reviewing and considering this!