### PR TITLE
add ffi and install.libs.R

### DIFF
--- a/2.0/pgenlibr/src/Makevars.in
+++ b/2.0/pgenlibr/src/Makevars.in
@@ -12,6 +12,10 @@ LIBDEFLATE = $(LIBDEFLATE_SOURCES:.c=.o)
 LIBPLINK2_SOURCES = $(INCL)/include/plink2_base.cc $(INCL)/include/plink2_bits.cc $(INCL)/include/pgenlib_ffi_support.cc $(INCL)/include/pgenlib_misc.cc $(INCL)/include/pgenlib_read.cc $(INCL)/include/plink2_bgzf.cc $(INCL)/include/plink2_htable.cc $(INCL)/include/plink2_memory.cc $(INCL)/include/plink2_string.cc $(INCL)/include/plink2_text.cc $(INCL)/include/plink2_thread.cc $(INCL)/include/plink2_zstfile.cc $(INCL)/include/pvar_ffi_support.cc
 LIBPLINK2 = $(LIBPLINK2_SOURCES:.cc=.o)
 
+
+LIBPFFI_SOURCES = $(INCL)/include/pvar_ffi_support.cpp $(INCL)/include/pgenlib_ffi_support.cpp
+LIBFFI = $(LIBPFFI_SOURCES:.cpp=.o)
+
 $(SHLIB): @ZSTD_SHLIB@ @LIBDEFLATE_SHLIB@ libPLINK2.a
 
 libPGZSTD.a: $(LIBZSTD)
@@ -20,10 +24,10 @@ libPGZSTD.a: $(LIBZSTD)
 libPGDEFLATE.a: $(LIBDEFLATE)
 	$(AR) rcs libPGDEFLATE.a $(LIBDEFLATE)
 
-libPLINK2.a: $(LIBPLINK2)
+libPLINK2.a: $(LIBPLINK2) $(LIBFFI)
 	$(AR) rcs libPLINK2.a $(LIBPLINK2)
 
 clean:
-	rm -f $(SHLIB) $(OBJECTS) @ZSTD_CLEAN@ @LIBDEFLATE_CLEAN@ $(LIBPLINK2)
+	rm -f $(SHLIB) $(OBJECTS) @ZSTD_CLEAN@ @LIBDEFLATE_CLEAN@ $(LIBPLINK2) $(LIBFFI)
 
 OBJECTS = pvar.o pgenlibr.o RcppExports.o

--- a/2.0/pgenlibr/src/install.libs.R
+++ b/2.0/pgenlibr/src/install.libs.R
@@ -1,0 +1,5 @@
+files <- Sys.glob(paste0("*", SHLIB_EXT))
+files <- c(files, dir(pattern="a$"))
+dest <- file.path(R_PACKAGE_DIR, paste0('libs', R_ARCH))
+dir.create(dest, recursive = TRUE, showWarnings = FALSE)
+file.copy(files, dest, overwrite = TRUE)


### PR DESCRIPTION
I'm writing a R package with an Rcpp package, and I'd like to access the plink code at the C++ level.  You made some small changes before based on this (https://github.com/chrchang/plink-ng/issues/283), and here I make two small changes so C++ code in other packages can access plink code at compile time.

1) Modify `Makevars.in` to include `pvar_ffi_support.o` and `pgenlib_ffi_support.o` in `libPLINK2.a`

2) Add `install.libs.R` to put static libraries in the default install path, so C++ in other packages can link against them.

In testing, this works on OSX and linux