### PR TITLE
deps: reinstate support for old versions of numpy?

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ jobs:
   wheel:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-13, macos-latest]
         python-version: [9, 10, 11, 12, 13]
@@ -44,7 +45,7 @@ jobs:
         working-directory: ./2.0/Python
         if: matrix.python-version <= 9 && matrix.os != 'macos-latest'
         run: |
-          pip install --force-reinstall --no-cache-dir 'numpy==2.0.0'
+          pip install --force-reinstall --no-cache-dir 'numpy==1.19.3'
           pytest tests/
 
       - name: Test against newest numpy version
@@ -59,6 +60,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        # The minimum and maximum supported versions of python that are not
+        # "end-of-life," "prerelease," or "feature": https://devguide.python.org/versions
         python-version: [9, 13]
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,22 +5,19 @@ on: [workflow_dispatch]
 jobs:
   build_wheels:
     name: Build wheels for ${{ matrix.arch }} ${{ matrix.os }} py3.${{ matrix.python }}
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python: [7, 8, 9, 10, 11, 12]
-        os: [ubuntu, macos]
+        python: [9, 10, 11, 12, 13]
+        os: [ubuntu-latest, macos-latest]
         arch: [x86_64, aarch64, universal2]
         exclude:
-          - os: macos
+          - os: ubuntu-latest
             arch: universal2
-            python: 7
-          - os: ubuntu
-            arch: universal2
-          - os: macos
+          - os: macos-latest
             arch: x86_64
-          - os: macos
+          - os: macos-latest
             arch: aarch64
 
     steps:
@@ -45,7 +42,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}-${{ matrix.arch }}-3${{ matrix.python }}
+          name: wheels-${{ startsWith(matrix.os, 'ubuntu') && 'ubuntu' || 'macos' }}-${{ matrix.arch }}-3${{ matrix.python }}
           path: ./wheelhouse/*.whl
 
   merge_wheels:
@@ -62,7 +59,9 @@ jobs:
   build_sdist:
     runs-on: ubuntu-latest
     env:
-      job_python_version: "3.12"
+      # The maximum supported version of python that is not
+      # "end-of-life," "prerelease," or "feature": https://devguide.python.org/versions
+      job_python_version: "3.13"
 
     steps:
       - name: Checkout

--- a/2.0/Python/.gitignore
+++ b/2.0/Python/.gitignore
@@ -2,3 +2,4 @@
 pgenlib.c
 pgenlib.cpp
 pgenlib.so
+__pycache__

--- a/2.0/Python/README.md
+++ b/2.0/Python/README.md
@@ -8,24 +8,20 @@ pip install 'pip>=20.3'
 pip install Pgenlib
 ```
 
-To build from GitHub instead, clone the repository:
+GitHub:
+```
+pip install 'pip>=20.3'
+pip install -e 'git+https://github.com/chrchang/plink-ng.git#egg=Pgenlib&subdirectory=2.0/Python'
+```
 
+Or install from a cloned copy:
 ```
 # clone repo
 git clone https://github.com/chrchang/plink-ng
 # go to python folder
 cd plink-ng/2.0/Python
-```
-
-Then install Cython and NumPy:
-```
-pip3 install "cython>=3.1.0" "numpy>=2.0.0"
-```
-
-and then build and install the package
-```
-python3 setup.py build_clib build_ext -i
-python3 setup.py install
+# install the package
+pip install -e .
 ```
 
 You can test the package with `pytest`.
@@ -43,4 +39,4 @@ with pg.PgenWriter("test.pgen".encode("utf-8"), 2, variant_ct=3, nonref_flags=Fa
 
 ```
 
-See tests/test_pgenlib.py for more sophisticated examples.
+See [tests/test_pgenlib.py](tests/test_pgenlib.py) for more sophisticated examples.

--- a/2.0/Python/setup.py
+++ b/2.0/Python/setup.py
@@ -104,6 +104,6 @@ setuptools.setup(
     libraries=[clib],
     ext_modules=cythonize(ext_modules),
     install_requires = [
-        "numpy>=2.0.0",
+        "numpy>=1.19.3",
     ],
 )


### PR DESCRIPTION
Hi @chrchang ,

I noticed that you recently upgraded pgenlib's minimum version of python from 1.19.0 to 2.0 around the time that you dropped support for py3.8

Cython packages that are compiled with numpy 2.0+ can still be imported and used alongside numpy <2.0

Are you planning to use any features of numpy 2.0+ at run-time (when pgenlib is imported by the user)? If not, I was wondering if I could still request support for old versions of numpy until they become incompatible with pgenlib's minimum python requirement?

This PR allows numpy <2.0 to be installed alongside pgenlib but maintains the requirement that numpy 2.0+ is installed when pgenlib is compiled and built. It also updates the CI workflow to test that things work even with numpy 1.19.3

I also updated the release.yaml workflow to support py3.13 and modified the README to suggest the use of `pip install -e`, which should install the requisite cython/numpy and compile pgenlib automatically