### PR TITLE
ci: enable py3.13 wheels and workaround pypy issue

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2
+        uses: pypa/cibuildwheel@v2.23
         with:
           package-dir: ./2.0/Python
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.1
+        uses: pypa/cibuildwheel@v2
         with:
           package-dir: ./2.0/Python
         env:

--- a/2.0/Python/pyproject.toml
+++ b/2.0/Python/pyproject.toml
@@ -1,7 +1,9 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools",
+    # pin setuptools on pypy to workaround this bug: https://github.com/pypa/distutils/issues/283 https://github.com/pypa/cibuildwheel/issues/1983
+    "setuptools < 72.2; platform_python_implementation == 'PyPy'",
+    "setuptools ; platform_python_implementation != 'PyPy'",
     "Cython>=3.1.0",
     "numpy>=2.0.0",
 ]


### PR DESCRIPTION
Sorry for the noise, @chrchang

Here's one more change to the release.yaml workflow to 1) upgrade to the latest `cibuildwheel` to allow py3.13 wheels to be built and to 2) workaround the pypy issue that you mentioned here:
https://github.com/chrchang/plink-ng/blob/8671e46090a987a35f100d82cd301eb5a9682a86/2.0/manylinux-build-wheels.sh#L14-L15

I tested this on my fork and was able to build all of the wheels:
https://github.com/aryarm/plink-ng/actions/runs/15167833912

Also, I noticed that the latest 0.92.0 is missing wheels for aarch64 and some others?
https://pypi.org/project/Pgenlib/0.92.0/#files
https://pypi.org/project/Pgenlib/0.91.0/#files
If that's because of something that is wrong with the workflow, please let me know! I'm always happy to fix it