### PR TITLE
--rm-dup: add match-mode=<id|pos> for position-keyed dedup

### DIFF
--- a/2.0/plink2.cc
+++ b/2.0/plink2.cc
@@ -403,6 +403,7 @@ typedef struct Plink2CmdlineStruct {
   VscoreFlags vscore_flags;
   AlleleAlphanumFlags allele_alphanum_flags;
   RmDupMode rmdup_mode;
+  RmDupMatchMode rmdup_match_mode;
   STD_ARRAY_DECL(FreqFilterMode, 4, filter_modes);
   SelectSidMissingnessMode select_sid_missingness_mode;
   SelectSidTiebreakMode select_sid_tiebreak_mode;
@@ -1554,7 +1555,11 @@ PglErr Plink2Core(const Plink2Cmdline* pcp, MakePlink2Flags make_plink2_flags, c
           }
         }
         if (pcp->rmdup_mode != kRmDup0) {
-          reterr = RmDup(sample_include, cip, variant_bps, TO_CONSTCPCONSTP(variant_ids_mutable), variant_id_htable, htable_dup_base, allele_idx_offsets, TO_CONSTCPCONSTP(allele_storage_mutable), pvar_qual_present, pvar_quals, pvar_filter_present, pvar_filter_npass, pvar_filter_storage, info_reload_slen? pvarname : nullptr, variant_cms, pcp->missing_varid_match, raw_sample_ct, sample_ct, raw_variant_ct, max_variant_id_slen, variant_id_htable_size, dup_ct, pcp->rmdup_mode, (pcp->command_flags1 / kfCommand1RmDupList) & 1, pcp->max_thread_ct, pgenname[0]? (&simple_pgr) : nullptr, variant_include, &variant_ct, outname, outname_end);
+          if (pcp->rmdup_match_mode == kRmDupMatchModePos) {
+            reterr = RmDupPos(cip, variant_bps, TO_CONSTCPCONSTP(variant_ids_mutable), pcp->rmdup_mode, (pcp->command_flags1 / kfCommand1RmDupList) & 1, raw_variant_ct, variant_include, &variant_ct, outname, outname_end);
+          } else {
+            reterr = RmDup(sample_include, cip, variant_bps, TO_CONSTCPCONSTP(variant_ids_mutable), variant_id_htable, htable_dup_base, allele_idx_offsets, TO_CONSTCPCONSTP(allele_storage_mutable), pvar_qual_present, pvar_quals, pvar_filter_present, pvar_filter_npass, pvar_filter_storage, info_reload_slen? pvarname : nullptr, variant_cms, pcp->missing_varid_match, raw_sample_ct, sample_ct, raw_variant_ct, max_variant_id_slen, variant_id_htable_size, dup_ct, pcp->rmdup_mode, (pcp->command_flags1 / kfCommand1RmDupList) & 1, pcp->max_thread_ct, pgenname[0]? (&simple_pgr) : nullptr, variant_include, &variant_ct, outname, outname_end);
+          }
           if (reterr || (!(pcp->command_flags1 & (~(kfCommand1Validate | kfCommand1PgenInfo | kfCommand1RmDupList))))) {
             goto Plink2Core_ret_1;
           }
@@ -3977,6 +3982,7 @@ int main(int argc, char** argv) {
     pc.select_sid_missingness_mode = kSelectSidMissingness0;
     pc.select_sid_tiebreak_mode = kSelectSidTiebreak0;
     pc.rmdup_mode = kRmDup0;
+    pc.rmdup_match_mode = kRmDupMatchModeId;
     for (uint32_t uii = 0; uii != 4; ++uii) {
       pc.filter_modes[uii] = kFreqFilterNonmajor;
     }
@@ -10984,15 +10990,33 @@ int main(int argc, char** argv) {
           pc.fa_flags |= kfFaRefFrom;
           pc.dependency_flags |= kfFilterPvarReq | kfFilterNonrefFlagsNeededSet;
         } else if (strequal_k_unsafe(flagname_p2, "m-dup")) {
-          if (unlikely(EnforceParamCtRange(argvk[arg_idx], param_ct, 0, 2))) {
+          if (unlikely(EnforceParamCtRange(argvk[arg_idx], param_ct, 0, 3))) {
             goto main_ret_INVALID_CMDLINE_2A;
           }
           RmDupMode rmdup_mode = kRmDup0;
+          RmDupMatchMode rmdup_match_mode = kRmDupMatchModeId;
+          uint32_t match_mode_seen = 0;
           for (uint32_t param_idx = 1; param_idx <= param_ct; ++param_idx) {
             const char* cur_modif = argvk[arg_idx + param_idx];
             const uint32_t cur_modif_slen = strlen(cur_modif);
             if (strequal_k(cur_modif, "list", cur_modif_slen)) {
               pc.command_flags1 |= kfCommand1RmDupList;
+            } else if (StrStartsWith(cur_modif, "match-mode=", cur_modif_slen)) {
+              if (unlikely(match_mode_seen)) {
+                logerrputs("Error: Multiple --rm-dup match-mode= modifiers.\n");
+                goto main_ret_INVALID_CMDLINE_A;
+              }
+              match_mode_seen = 1;
+              const char* mode_str = &(cur_modif[strlen("match-mode=")]);
+              const uint32_t mode_slen = cur_modif_slen - strlen("match-mode=");
+              if (strequal_k(mode_str, "id", mode_slen)) {
+                rmdup_match_mode = kRmDupMatchModeId;
+              } else if (likely(strequal_k(mode_str, "pos", mode_slen))) {
+                rmdup_match_mode = kRmDupMatchModePos;
+              } else {
+                snprintf(g_logbuf, kLogbufSize, "Error: Invalid --rm-dup match-mode argument '%s' (expected 'id' or 'pos').\n", mode_str);
+                goto main_ret_INVALID_CMDLINE_WWA;
+              }
             } else if (rmdup_mode != kRmDup0) {
               logerrputs("Error: Invalid --rm-dup argument sequence.\n");
               goto main_ret_INVALID_CMDLINE_A;
@@ -11011,6 +11035,16 @@ int main(int argc, char** argv) {
               goto main_ret_INVALID_CMDLINE_WWA;
             }
           }
+          if (rmdup_match_mode == kRmDupMatchModePos) {
+            // Mismatch-based actions compare allele/INFO/genotype data,
+            // meaningless for (CHROM, POS) dups (different ALTs by
+            // construction).  Reject rather than silently behave like
+            // exclude-all.
+            if (unlikely((rmdup_mode == kRmDupRetainMismatch) || (rmdup_mode == kRmDupExcludeMismatch))) {
+              logerrputs("Error: --rm-dup match-mode=pos only supports the 'error', 'exclude-all', and\n'force-first' actions (the mismatch-based actions compare allele/INFO data,\nwhich isn't meaningful when duplicates are keyed by (CHROM, POS) alone).\n");
+              goto main_ret_INVALID_CMDLINE_A;
+            }
+          }
           if (rmdup_mode < kRmDupExcludeAll) {
             if (rmdup_mode == kRmDup0) {
               rmdup_mode = kRmDupError;
@@ -11018,6 +11052,7 @@ int main(int argc, char** argv) {
             pc.dependency_flags |= kfFilterOpportunisticPgen;
           }
           pc.rmdup_mode = rmdup_mode;
+          pc.rmdup_match_mode = rmdup_match_mode;
           pc.dependency_flags |= kfFilterPvarReq;
         } else if (strequal_k_unsafe(flagname_p2, "ecover-var-ids")) {
           if (unlikely(EnforceParamCtRange(argvk[arg_idx], param_ct, 1, 4))) {

--- a/2.0/plink2_filter.cc
+++ b/2.0/plink2_filter.cc
@@ -1164,6 +1164,132 @@ PglErr RmDup(const uintptr_t* sample_include, const ChrInfo* cip, const uint32_t
   return reterr;
 }
 
+PglErr RmDupPos(const ChrInfo* cip, const uint32_t* variant_bps, const char* const* variant_ids, RmDupMode rmdup_mode, uint32_t save_list, uint32_t raw_variant_ct, uintptr_t* variant_include, uint32_t* variant_ct_ptr, char* outname, char* outname_end) {
+  // Position-keyed analogue of RmDup.  Per chromosome: popcount + a single
+  // linear pass over variant_include.  No hash table, no INFO reload, no
+  // genotype comparison -- (CHROM, POS) dups are typically atomized
+  // multi-allelics with intentionally distinct ALTs.
+  FILE* list_file = nullptr;
+  PglErr reterr = kPglRetSuccess;
+  {
+    const uint32_t orig_variant_ct = *variant_ct_ptr;
+    if (orig_variant_ct < 2) {
+      logputs("Note: Skipping --rm-dup match-mode=pos since fewer than 2 variants remain.\n");
+      goto RmDupPos_ret_1;
+    }
+    const uintptr_t raw_variant_ctl = BitCtToWordCt(raw_variant_ct);
+    char* list_write_iter = g_textbuf;
+    char* list_flush = &(list_write_iter[kMaxMediumLine]);
+    uint32_t duplicate_ct = 0;        // variants excluded
+    uint32_t duplicate_group_ct = 0;  // distinct positions with > 1 hit
+    const uint32_t chr_ct = cip->chr_ct;
+    for (uint32_t chr_fo_idx = 0; chr_fo_idx != chr_ct; ++chr_fo_idx) {
+      const uint32_t vidx_start = cip->chr_fo_vidx_start[chr_fo_idx];
+      const uint32_t vidx_end = cip->chr_fo_vidx_start[chr_fo_idx + 1];
+      // Pre-count so the BitIter1 loop has a safe upper bound (idiomatic
+      // plink2; BitIter1 doesn't self-terminate).
+      const uint32_t cur_chr_variant_ct = PopcountBitRange(variant_include, vidx_start, vidx_end);
+      if (!cur_chr_variant_ct) {
+        continue;
+      }
+      uintptr_t variant_uidx_base;
+      uintptr_t cur_bits;
+      BitIter1Start(variant_include, vidx_start, &variant_uidx_base, &cur_bits);
+      // variant_idx > 0 gates "have-previous-variant" so prev_bp/prev_uidx
+      // initial values are never read (no sentinel value collision).
+      uint32_t prev_bp = 0;
+      uint32_t prev_uidx = 0;
+      uint32_t in_run = 0;  // extending a duplicate run
+      for (uint32_t variant_idx = 0; variant_idx != cur_chr_variant_ct; ++variant_idx) {
+        const uintptr_t variant_uidx = BitIter1(variant_include, &variant_uidx_base, &cur_bits);
+        const uint32_t cur_bp = variant_bps[variant_uidx];
+        if (variant_idx) {
+          if (cur_bp == prev_bp) {
+            if (!in_run) {
+              ++duplicate_group_ct;
+              in_run = 1;
+              if (save_list) {
+                if (!list_file) {
+                  snprintf(outname_end, kMaxOutfnameExtBlen, ".rmdup.list");
+                  if (unlikely(fopen_checked(outname, FOPEN_WB, &list_file))) {
+                    goto RmDupPos_ret_OPEN_FAIL;
+                  }
+                }
+                list_write_iter = strcpya(list_write_iter, variant_ids[prev_uidx]);
+                AppendBinaryEoln(&list_write_iter);
+                if (unlikely(fwrite_ck(list_flush, list_file, &list_write_iter))) {
+                  goto RmDupPos_ret_WRITE_FAIL;
+                }
+              }
+              if (rmdup_mode == kRmDupExcludeAll) {
+                ClearBit(prev_uidx, variant_include);
+                ++duplicate_ct;
+              }
+            }
+            if (save_list) {
+              list_write_iter = strcpya(list_write_iter, variant_ids[variant_uidx]);
+              AppendBinaryEoln(&list_write_iter);
+              if (unlikely(fwrite_ck(list_flush, list_file, &list_write_iter))) {
+                goto RmDupPos_ret_WRITE_FAIL;
+              }
+            }
+            // Clear non-leading dup.  force-first keeps prev_uidx; exclude-all
+            // cleared it above.
+            ClearBit(variant_uidx, variant_include);
+            ++duplicate_ct;
+          } else {
+            // variant_bps must be non-decreasing per chromosome; bail with a
+            // --sort-vars pointer if not.
+            if (unlikely(cur_bp < prev_bp)) {
+              snprintf(g_logbuf, kLogbufSize, "Error: --rm-dup match-mode=pos requires variants to be sorted by position within each chromosome.  Variant '%s' is out of order; use --sort-vars first.\n", variant_ids[variant_uidx]);
+              goto RmDupPos_ret_INCONSISTENT_INPUT_WW;
+            }
+            in_run = 0;
+          }
+        }
+        prev_uidx = variant_uidx;
+        prev_bp = cur_bp;
+      }
+    }
+    if (rmdup_mode == kRmDupError) {
+      if (duplicate_group_ct) {
+        snprintf(g_logbuf, kLogbufSize, "Error: --rm-dup match-mode=pos: found %u duplicate-position group(s).  Re-run with 'exclude-all' or 'force-first' to remove them.\n", duplicate_group_ct);
+        goto RmDupPos_ret_INCONSISTENT_INPUT_WW;
+      }
+      logputs("--rm-dup match-mode=pos: no duplicate positions found.\n");
+      goto RmDupPos_ret_1;
+    }
+    if (!duplicate_group_ct) {
+      logputs("Note: --rm-dup match-mode=pos found no duplicate positions; nothing excluded.\n");
+      goto RmDupPos_ret_1;
+    }
+    if (list_file) {
+      if (unlikely(fclose_flush_null(list_flush, list_write_iter, &list_file))) {
+        goto RmDupPos_ret_WRITE_FAIL;
+      }
+    }
+    const uint32_t new_variant_ct = PopcountWords(variant_include, raw_variant_ctl);
+    logprintfww("--rm-dup match-mode=pos%s: %u duplicate position group%s (%u variant%s excluded), %u variant%s remaining.\n", (rmdup_mode == kRmDupForceFirst)? " force-first" : " exclude-all", duplicate_group_ct, (duplicate_group_ct == 1)? "" : "s", duplicate_ct, (duplicate_ct == 1)? "" : "s", new_variant_ct, (new_variant_ct == 1)? "" : "s");
+    *variant_ct_ptr = new_variant_ct;
+  }
+  while (0) {
+  RmDupPos_ret_OPEN_FAIL:
+    reterr = kPglRetOpenFail;
+    break;
+  RmDupPos_ret_WRITE_FAIL:
+    reterr = kPglRetWriteFail;
+    break;
+  RmDupPos_ret_INCONSISTENT_INPUT_WW:
+    WordWrapB(0);
+    logerrputsb();
+    reterr = kPglRetInconsistentInput;
+    break;
+  }
+ RmDupPos_ret_1:
+  fclose_cond(list_file);
+  return reterr;
+}
+
 void RandomThinProb(const char* flagname_p, const char* unitname, double thin_keep_prob, uint32_t raw_item_ct, sfmt_t* sfmtp, uintptr_t* item_include, uint32_t* item_ct_ptr) {
   // possible todo: try using truncated geometric distribution, like --dummy
   // can also parallelize this

--- a/2.0/plink2_filter.h
+++ b/2.0/plink2_filter.h
@@ -63,7 +63,21 @@ ENUM_U31_DEF_START()
   kRmDupForceFirst
 ENUM_U31_DEF_END(RmDupMode);
 
+// --rm-dup match key.  'id' (default) preserves existing RmDup behavior;
+// 'pos' dedups by (chrom_idx, bp) via RmDupPos.  Mismatch-based actions
+// don't apply to pos-mode (different ALTs by construction); parser rejects
+// those combinations.
+ENUM_U31_DEF_START()
+  kRmDupMatchModeId,
+  kRmDupMatchModePos
+ENUM_U31_DEF_END(RmDupMatchMode);
+
 PglErr RmDup(const uintptr_t* sample_include, const ChrInfo* cip, const uint32_t* variant_bps, const char* const* variant_ids, const uint32_t* variant_id_htable, const uint32_t* htable_dup_base, const uintptr_t* allele_idx_offsets, const char* const* allele_storage, const uintptr_t* pvar_qual_present, const float* pvar_quals, const uintptr_t* pvar_filter_present, const uintptr_t* pvar_filter_npass, const char* const* pvar_filter_storage, const char* pvar_info_reload, const double* variant_cms, const char* missing_varid_match, uint32_t raw_sample_ct, uint32_t sample_ct, uint32_t raw_variant_ct, uint32_t max_variant_id_slen, uintptr_t variant_id_htable_size, uint32_t orig_dup_ct, RmDupMode rmdup_mode, uint32_t save_list, uint32_t max_thread_ct, PgenReader* simple_pgrp, uintptr_t* variant_include, uint32_t* variant_ct_ptr, char* outname, char* outname_end);
+
+// Position-keyed --rm-dup.  Walks variant_include per chromosome (relying on
+// plink2's non-decreasing variant_bps invariant), finds bp-runs, applies the
+// action.  Only error / exclude-all / force-first / list are supported.
+PglErr RmDupPos(const ChrInfo* cip, const uint32_t* variant_bps, const char* const* variant_ids, RmDupMode rmdup_mode, uint32_t save_list, uint32_t raw_variant_ct, uintptr_t* variant_include, uint32_t* variant_ct_ptr, char* outname, char* outname_end);
 
 void RandomThinProb(const char* flagname_p, const char* unitname, double thin_keep_prob, uint32_t raw_item_ct, sfmt_t* sfmtp, uintptr_t* item_include, uint32_t* item_ct_ptr);
 

--- a/2.0/plink2_help.cc
+++ b/2.0/plink2_help.cc
@@ -291,11 +291,19 @@ PglErr DispHelp(const char* const* argvk, uint32_t param_ct) {
 , stdout);
     }
     HelpPrint("rm-dup\0list-duplicate-vars\0", &help_ctrl, 1,
-"  --rm-dup [mode] ['list']\n"
-"    Remove all but one instance of each duplicate-ID variant (ignoring the\n"
-"    missing ID), and (with the 'list' modifier) write a list of duplicated IDs\n"
-"    to <output prefix>.rmdup.list.\n"
-"    The following modes of operation are supported:\n"
+"  --rm-dup [mode] ['list'] ['match-mode='<key>]\n"
+"    Remove all but one instance of each duplicate variant (ignoring variants\n"
+"    with the missing ID), and (with the 'list' modifier) write a list of\n"
+"    duplicated IDs to <output prefix>.rmdup.list.\n"
+"    'match-mode=' picks the duplicate-detection key:\n"
+"    * 'id' (default) matches on variant ID (existing behavior).\n"
+"    * 'pos' matches on (CHROM, POS), useful when biallelic rows at the same\n"
+"      position have distinct IDs (e.g., after upstream atomization of\n"
+"      multi-allelic records with 'bcftools norm -m-').  Only the 'error',\n"
+"      'exclude-all', and 'force-first' actions apply; the mismatch-based\n"
+"      modes are rejected since pos-mode duplicates have different alleles\n"
+"      by construction.\n"
+"    The following action modes of operation are supported:\n"
 "    * 'error' (default) causes this to error out when there's a genotype data\n"
 "      or other mismatch between the records.  A list of affected IDs is written\n"
 "      to <output prefix>.rmdup.mismatch.\n"
@@ -304,9 +312,9 @@ PglErr DispHelp(const char* const* argvk, uint32_t param_ct) {
 "      one instance is kept.  The .rmdup.mismatch file is also written.\n"
 "    * 'exclude-mismatch' removes all instances of duplicate-ID mismatched\n"
 "      variants instead.\n"
-"    * 'exclude-all' causes all instances of duplicate-ID variants to be\n"
-"      removed, even when the actual records are identical.\n"
-"    * 'force-first' causes only the first instance of duplicate-ID variants to\n"
+"    * 'exclude-all' causes all instances of duplicate variants to be removed,\n"
+"      even when the actual records are identical.\n"
+"    * 'force-first' causes only the first instance of duplicate variants to\n"
 "      be kept, under all circumstances.\n\n"
               );
     HelpPrint("make-pgen\0make-bpgen\0make-bed\0make-just-pvar\0make-just-psam\0make-pfile\0make-bpfile\0make-bfile\0", &help_ctrl, 1,


### PR DESCRIPTION
Addresses #330.  Adds a `match-mode=<id|pos>` modifier to `--rm-dup`: the default `id` preserves the existing behavior verbatim, while `pos` dispatches to a new `RmDupPos` that dedups by (CHROM, POS) -- the atomized-multi-allelic case from the issue.

Sample output (the #330 reproducer):

```
$ plink2 --vcf dup_pos.vcf --rm-dup force-first match-mode=pos --make-pgen --out dedup
--rm-dup match-mode=pos force-first: 1 duplicate position group (1 variant excluded), 1 variant remaining.
```

## Design

`RmDupPos` is a separate function so the ID-mode `RmDup` doesn't have to grow new mode branches around its allele/INFO/genotype-comparison logic.  Pos-mode skips the ID-htable build, INFO reload, and allele/qual/info/genotype mismatch checks -- none of those are meaningful when dups are detected by (CHROM, POS) alone (atomized-multi-allelic dups have intentionally distinct ALTs by construction).

Single linear pass per chromosome, bounded by `PopcountBitRange` to match the existing plink2 iteration idiom.  Relies on plink2's invariant that `variant_bps` is non-decreasing within a chromosome's vidx range; emits a `--sort-vars`-pointing error if violated.  `retain-mismatch` / `exclude-mismatch` actions are rejected at parse when combined with `match-mode=pos`.

## Validation

9 tests, all pass:

| # | What | Result |
|---|---|---|
| 1 | `--rm-dup force-first` on distinct-ID 2-row VCF | byte-identical .pgen to baseline ✓ |
| 2 | `match-mode=pos force-first` on the #330 reproducer | 1 of 2 survives ✓ |
| 3 | `match-mode=pos exclude-all` on 3-row VCF | dup pair dropped, lone variant kept ✓ |
| 4 | `match-mode=pos error` with dups | exit 7 + diagnostic ✓ |
| 5 | `match-mode=pos retain-mismatch` | parser rejects (exit 8) ✓ |
| 6 | `--rm-dup force-first` on 5M-VCF (no match-mode) | byte-identical to baseline ✓ |
| 7 | 4-way + lone + 2-way mixed | survivors `v100a, v200, v300a` ✓ |
| 8 | Unsorted-within-chromosome `(500, 500, 300)` | sortedness diagnostic fires ✓ |
| 9 | Cross-chromosome (chr1:100 + chr2:100 + dups on each) | `c1a, c1c, c2a, c2b` survive ✓ |

Build clean under `-Wall -Wextra -Wshadow -Wold-style-cast`.

## Notes

- ID-mode default behavior is unchanged; the `Plink2Cmdline` struct gains a `rmdup_match_mode` field that defaults to `kRmDupMatchModeId`.
- `--rm-dup list match-mode=pos` writes the same `<out>.rmdup.list` format as ID-mode.
- `match-mode=id-or-pos` (drop on either key) is mentioned in #330 as the eventual use case, but is deferred -- the dup-group merging semantics for `force-first` need design discussion before code.