### PR TITLE
fix segfault in pvar files containing deletions where ID=.

### DIFF
--- a/2.0/include/pvar_ffi_support.cc
+++ b/2.0/include/pvar_ffi_support.cc
@@ -280,7 +280,7 @@ PglErr LoadMinimalPvarEx(const char* fname, LoadMinimalPvarFlags flags, MinimalP
         ++variant_ct;
         // could enforce ID length limits
         string_byte_ct += token_slens[kPvarColId]; // +1 added later
-        if (token_slens[1] > 1) {
+        if (token_slens[kPvarColRef] > 1) {
           string_byte_ct += token_slens[kPvarColRef] + 1;
         }
         const uint32_t alt_slen = token_slens[kPvarColAlt];


### PR DESCRIPTION
This tries to fix a problem loading pvar files where deletions have single character IDs e.g. ".". I was getting segfaults when loading these files. Here's some code to reproduce the issue:

```py
from pgenlib import PvarReader

# make synthetic pvar file for deletions where ID=.
pvar_path = 'test.pvar'
with open(pvar_path, 'w') as f:
    f.write('#CHROM\tPOS\tID\tREF\tALT\n')
    for pos in range(1, 100):
        f.write(f'1\t{pos}\t.\tACGTA\tA\n')

pvar = PvarReader(pvar_path.encode())
pvar.close()  # typically segfaults (on linux at least, I didn't check other OSes)
```