### PR TITLE
--bcf: detect non-rewindable input up front, stop masking decompression errors (#246)

### DIFF
--- a/2.0/plink2_import.cc
+++ b/2.0/plink2_import.cc
@@ -7382,6 +7382,24 @@ PglErr BcfToPgen(const char* bcfname, const char* preexisting_psamname, const ch
   STPgenWriter spgw;
   PreinitSpgw(&spgw);
   {
+    // BCF import requires two passes over the file, so reject
+    // process-substitution/named-pipe input up front (as VcfToPgen() does).
+    // This also lets the rewind between the two passes report its real
+    // underlying error, instead of blaming an unrewindable stream.
+    reterr = ForceNonFifo(bcfname);
+    if (unlikely(reterr)) {
+      if (reterr == kPglRetOpenFail) {
+        const uint32_t slen = strlen(bcfname);
+        if (!StrEndsWith(bcfname, ".bcf", slen)) {
+          logerrprintfww("Error: Failed to open %s : %s. (--bcf expects a complete filename; did you forget '.bcf' at the end?)\n", bcfname, strerror(errno));
+        } else {
+          logerrprintfww(kErrprintfFopen, bcfname, strerror(errno));
+        }
+        goto BcfToPgen_ret_OPEN_FAIL;
+      }
+      logerrprintfww(kErrprintfRewind, "--bcf file");
+      goto BcfToPgen_ret_1;
+    }
     // See TextFileOpenInternal().
     bcffile = fopen(bcfname, FOPEN_RB);
     if (unlikely(!bcffile)) {
@@ -8517,10 +8535,11 @@ PglErr BcfToPgen(const char* bcfname, const char* preexisting_psamname, const ch
 
     reterr = BgzfRawMtStreamRewind(&bgzf, &bgzf_errmsg);
     if (unlikely(reterr)) {
-      if (reterr == kPglRetDecompressFail) {
-        DPrintf("DecompressFail during initial rewind");
-        goto BcfToPgen_ret_REWIND_FAIL;
-      }
+      // We verified at the beginning of this function that the input is not a
+      // FIFO, so a decompression failure here reflects a real problem with the
+      // file rather than an unrewindable stream; report the underlying error
+      // instead of the misleading "could not be scanned twice" message.
+      DPrintf("BgzfRawMtStreamRewind failure during initial rewind");
       goto BcfToPgen_ret_BGZF_FAIL;
     }
     {


### PR DESCRIPTION
Fixes #246.

### Problem

`BcfToPgen()` reads the input twice, but unlike `VcfToPgen()` and `OxGenToPgen()` it never called `ForceNonFifo()`. Two consequences:

1. Process-substitution / named-pipe input was only detected after a full first pass over the file.
2. The place where it *was* detected also swallowed real errors:

```c
reterr = BgzfRawMtStreamRewind(&bgzf, &bgzf_errmsg);
if (unlikely(reterr)) {
  if (reterr == kPglRetDecompressFail) {
    DPrintf("DecompressFail during initial rewind");
    goto BcfToPgen_ret_REWIND_FAIL;   // reports "could not be scanned twice"
  }
  goto BcfToPgen_ret_BGZF_FAIL;
}
```

`BgzfRawMtStreamRetarget()` returns `kPglRetDecompressFail` both when the pending first-pass decompression job failed (`prev_cwd->invalid_bgzf`) and when the post-rewind header is not valid BGZF. The first of those is a genuine data problem, and it was being reported as an unrewindable stream. That is the overly general message this issue is about.

### Change

1. Call `ForceNonFifo()` at the top of `BcfToPgen()`, mirroring `VcfToPgen()`. Pipe input now fails immediately with the accurate message, before any work is done, and keeps the existing "`--bcf` expects a complete filename" hint on open failure.
2. With the FIFO case excluded earlier, the rewind no longer reinterprets a decompression failure. It falls through to `BcfToPgen_ret_BGZF_FAIL`, which prints the real underlying error along with the bgzf error message, and still prints the rewind message for an actual `kPglRetRewindFail` (so a non-seekable-but-not-FIFO filesystem is still diagnosed correctly).

### Verification

macOS/arm64, `2.0/Makefile` dev build.

`2.0/Tests/run_tests.sh` passes 8/8, unchanged from the pre-patch baseline on the same machine.

Behaviour on a small `bcftools`-generated `.bcf`:

| input | before | after |
|---|---|---|
| regular `.bcf` | imports | imports, byte-identical output |
| `<(cat tiny.bcf)` | rewind message, after first pass | rewind message, immediately |
| named pipe | rewind message, after first pass | rewind message, immediately |
| missing `nope.bcf` | `Failed to open ...` | unchanged |
| missing `nope.dat` | `Failed to open ... (--bcf expects a complete filename ...)` | unchanged |
| truncated `.bcf` | `decompression failure: Malformed BGZF block` | unchanged |
| corrupted body | `decompression failure: Malformed BGZF block` | unchanged |
| header-only `.bcf` | exit 13 (`DegenerateData`) | unchanged |

The truncated/corrupted cases already failed during the first pass, so they were not hitting the suppressed branch; the change makes the suppressed branch report the same style of message when it is reached.

I could not reproduce the original google-groups report (the reporter saw the message on an ordinary internal drive), so this does not claim to fix that root cause. It removes the masking so that the next report carries the real error, and it makes the pipe case fail fast.

Generated with [Claude Code](https://claude.com/claude-code)