### PR TITLE
chrX: treat het haploid hardcalls as missing in allele-count computation (#341)

### DIFF
--- a/2.0/Tests/TEST_CHRX_HAPLOID/.gitignore
+++ b/2.0/Tests/TEST_CHRX_HAPLOID/.gitignore
@@ -1,0 +1,5 @@
+*.log
+chrx*
+subset.id
+plink1_*
+plink2_*

--- a/2.0/Tests/TEST_CHRX_HAPLOID/check_counts.py
+++ b/2.0/Tests/TEST_CHRX_HAPLOID/check_counts.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Verify that --freq counts agrees with --geno-counts on chrX.
+
+Both are computed from the same hardcalls, so for a biallelic variant
+
+  ALT_CTS == HET_REF_ALT_CTS + 2 * TWO_ALT_GENO_CTS + HAP_ALT_CTS
+  OBS_CT  == 2 * (HOM_REF_CT + HET_REF_ALT_CTS + TWO_ALT_GENO_CTS)
+             + HAP_REF_CT + HAP_ALT_CTS
+
+must hold exactly, with het haploid calls landing in MISSING_CT and thus in
+neither side.  ALT_CTS must also be an integer.
+"""
+import sys
+
+
+def load(fname):
+    rows = {}
+    with open(fname) as f:
+        header = f.readline().split()
+        id_idx = header.index('ID')
+        for line in f:
+            fields = line.split()
+            rows[fields[id_idx]] = dict(zip(header, fields))
+    return rows
+
+
+acount = load(sys.argv[1])
+gcount = load(sys.argv[2])
+assert len(acount) == len(gcount), 'variant count mismatch'
+assert acount, 'no variants'
+
+problem_ct = 0
+for variant_id, arow in acount.items():
+    grow = gcount[variant_id]
+    hom_ref = int(grow['HOM_REF_CT'])
+    het = int(grow['HET_REF_ALT_CTS'])
+    two_alt = int(grow['TWO_ALT_GENO_CTS'])
+    hap_ref = int(grow['HAP_REF_CT'])
+    hap_alt = int(grow['HAP_ALT_CTS'])
+    expected_alt = het + 2 * two_alt + hap_alt
+    expected_obs = 2 * (hom_ref + het + two_alt) + hap_ref + hap_alt
+    alt_str = arow['ALT_CTS']
+    obs_str = arow['OBS_CT']
+    if ('.' in alt_str) or ('.' in obs_str):
+        print('%s: non-integer --freq counts output: ALT_CTS %s, OBS_CT %s' %
+              (variant_id, alt_str, obs_str))
+        problem_ct += 1
+        continue
+    if (int(alt_str) != expected_alt) or (int(obs_str) != expected_obs):
+        print('%s: --freq counts says ALT_CTS %s / OBS_CT %s, '
+              '--geno-counts implies %u / %u' %
+              (variant_id, alt_str, obs_str, expected_alt, expected_obs))
+        problem_ct += 1
+
+if problem_ct:
+    sys.exit('%u variant(s) inconsistent' % (problem_ct,))

--- a/2.0/Tests/TEST_CHRX_HAPLOID/make_chrx_vcf.py
+++ b/2.0/Tests/TEST_CHRX_HAPLOID/make_chrx_vcf.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Emit a small chrX .vcf plus a matching sex file.
+
+Half the male calls are deliberately heterozygous, i.e. het haploid.  Those are
+malformed input, and every plink command that reports per-variant counts is
+expected to treat them as missing.
+"""
+import random
+import sys
+
+seed = int(sys.argv[1])
+sample_ct = int(sys.argv[2])
+variant_ct = int(sys.argv[3])
+random.seed(seed)
+
+samples = ['S%u' % (i,) for i in range(sample_ct)]
+sexes = [random.choice([1, 2]) for _ in range(sample_ct)]
+
+with open('chrx.vcf', 'w') as f:
+    f.write('##fileformat=VCFv4.2\n')
+    f.write('##contig=<ID=X,length=156040895>\n')
+    f.write('##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n')
+    f.write('#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t')
+    f.write('\t'.join(samples))
+    f.write('\n')
+    for uii in range(variant_ct):
+        calls = []
+        for sample_idx in range(sample_ct):
+            urand = random.random()
+            if urand < 0.05:
+                calls.append('./.')
+            elif sexes[sample_idx] == 1:
+                # 20% of the male calls are het haploid.
+                if random.random() < 0.2:
+                    calls.append('0/1')
+                else:
+                    calls.append(random.choice(['0/0', '1/1']))
+            else:
+                calls.append(random.choice(['0/0', '0/1', '1/1']))
+        # Stay clear of the PAR regions so that --split-par is not needed.
+        f.write('X\t%u\tx%u\tA\tG\t.\t.\t.\tGT\t' % (20000000 + uii * 1000, uii))
+        f.write('\t'.join(calls))
+        f.write('\n')
+
+with open('chrx_sex.txt', 'w') as f:
+    f.write('#IID\tSEX\n')
+    for sample_id, sex in zip(samples, sexes):
+        f.write('%s\t%u\n' % (sample_id, sex))

--- a/2.0/Tests/TEST_CHRX_HAPLOID/run_tests.sh
+++ b/2.0/Tests/TEST_CHRX_HAPLOID/run_tests.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -exo pipefail
+
+# chrX fileset where 20% of the male calls are het haploid.  Those calls are
+# malformed input, and every per-variant count is expected to treat them as
+# missing.
+python3 make_chrx_vcf.py 1 200 300
+
+$1/plink2 $2 $3 --vcf chrx.vcf --update-sex chrx_sex.txt --make-pgen --out plink2_chrx
+
+$1/plink2 $2 $3 --pfile plink2_chrx --freq counts --out plink2_acount
+$1/plink2 $2 $3 --pfile plink2_chrx --geno-counts --out plink2_gcount
+python3 check_counts.py plink2_acount.acount plink2_gcount.gcount
+
+# --set-invalid-haploid-missing removes the het haploid calls up front, so it
+# must not change any of these counts.
+$1/plink2 $2 $3 --pfile plink2_chrx --set-invalid-haploid-missing --make-pgen --out plink2_chrx_clean
+$1/plink2 $2 $3 --pfile plink2_chrx_clean --freq counts --out plink2_acount_clean
+$1/plink2 $2 $3 --pfile plink2_chrx_clean --geno-counts --out plink2_gcount_clean
+diff -q plink2_acount.acount plink2_acount_clean.acount
+diff -q plink2_gcount.gcount plink2_gcount_clean.gcount
+
+# Same check on a sample subset, to cover the sample_ct != raw_sample_ct code
+# path.
+head -n 100 plink2_chrx.psam | tail -n +2 | cut -f 1 > subset.id
+$1/plink2 $2 $3 --pfile plink2_chrx --keep subset.id --freq counts --out plink2_acount_sub
+$1/plink2 $2 $3 --pfile plink2_chrx --keep subset.id --geno-counts --out plink2_gcount_sub
+python3 check_counts.py plink2_acount_sub.acount plink2_gcount_sub.gcount
+
+# And single-threaded, since the counts are accumulated per thread.
+$1/plink2 $2 --threads 1 --pfile plink2_chrx --freq counts --out plink2_acount_st
+diff -q plink2_acount.acount plink2_acount_st.acount

--- a/2.0/Tests/run_tests.sh
+++ b/2.0/Tests/run_tests.sh
@@ -58,4 +58,9 @@ cd TEST_ONE_WAY_EXPORT
 cd ..
 echo "TEST_ONE_WAY_EXPORT passed."
 
+cd TEST_CHRX_HAPLOID
+./run_tests.sh $d $2 $3 > TEST_CHRX_HAPLOID.log
+cd ..
+echo "TEST_CHRX_HAPLOID passed."
+
 echo "All tests passed."

--- a/2.0/plink2_data.cc
+++ b/2.0/plink2_data.cc
@@ -2641,6 +2641,10 @@ THREAD_FUNC_DECL LoadAlleleAndGenoCountsThread(void* raw_arg) {
               uintptr_t alt1_ct = 4 * genocounts[2] + 2 * genocounts[1] - 2 * sex_specific_genocounts[2] - hethap_ct;  // nonmales count twice
               uint64_t alt1_ddosage = 0;  // in 32768ths, nonmales count twice
               uint32_t additional_dosage_ct = 0;  // missing hardcalls only; nonmales count twice
+              // Male het hardcalls which have been replaced by a dosage; the
+              // loops below already subtract their remaining half-allele, so
+              // they must be excluded from the hethap correction afterward.
+              uint32_t hethap_dosage_ct = 0;
               // bugfix (12 Jul 2018): dosage_present may be null if dosage_ct
               // == 0
               if (pgv.dosage_ct) {
@@ -2659,6 +2663,7 @@ THREAD_FUNC_DECL LoadAlleleAndGenoCountsThread(void* raw_arg) {
                     const uintptr_t hardcall_code = GetNyparrEntry(pgv.genovec, sample_uidx);
                     if (hardcall_code != 3) {
                       alt1_ct -= hardcall_code * sex_multiplier;
+                      hethap_dosage_ct += (hardcall_code == 1) && (sex_multiplier == 1);
                     } else {
                       additional_dosage_ct += sex_multiplier;
                     }
@@ -2673,6 +2678,7 @@ THREAD_FUNC_DECL LoadAlleleAndGenoCountsThread(void* raw_arg) {
                       const uintptr_t hardcall_code = GetNyparrEntry(pgv.genovec, sample_uidx);
                       if (hardcall_code != 3) {
                         alt1_ct -= hardcall_code * sex_multiplier;
+                        hethap_dosage_ct += (hardcall_code == 1) && (sex_multiplier == 1);
                       } else {
                         additional_dosage_ct += sex_multiplier;
                       }
@@ -2680,11 +2686,18 @@ THREAD_FUNC_DECL LoadAlleleAndGenoCountsThread(void* raw_arg) {
                   }
                 }
               }
+              // Heterozygous haploid calls are treated as missing, for
+              // consistency with --geno-counts, --hardy, and PLINK 1.9.  The
+              // alt1_ct initializer above only removed half of each such call
+              // (male het contributes 2 - 1 = 1 half-allele), and
+              // weighted_obs_ct below still counts the male as an observation.
+              const uint32_t hethap_hardcall_ct = hethap_ct - hethap_dosage_ct;
+              alt1_ct -= hethap_hardcall_ct;
               alt1_ddosage += alt1_ct * S_CAST(uint64_t, kDosageMid);
 
               // bugfix (14 May 2018): this didn't correctly distinguish
               // between missing vs. 'replaced' hardcalls
-              const uintptr_t weighted_obs_ct = (2 * (sample_ct - genocounts[3]) - male_ct + sex_specific_genocounts[3] + additional_dosage_ct) * (2 * k1LU);
+              const uintptr_t weighted_obs_ct = (2 * (sample_ct - genocounts[3]) - male_ct + sex_specific_genocounts[3] + additional_dosage_ct - hethap_hardcall_ct) * (2 * k1LU);
 
               allele_ddosages[cur_allele_idx_offset] = weighted_obs_ct * S_CAST(uint64_t, kDosageMid) - alt1_ddosage;
               allele_ddosages[cur_allele_idx_offset + 1] = alt1_ddosage;


### PR DESCRIPTION
Addresses the biallelic chrX half of #341.

### Problem

In `LoadAlleleAndGenoCountsThread()` (`2.0/plink2_data.cc`), the biallelic chrX branch starts from

```c
uintptr_t alt1_ct = 4 * genocounts[2] + 2 * genocounts[1] - 2 * sex_specific_genocounts[2] - hethap_ct;  // nonmales count twice
```

`alt1_ct` is in half-allele units. A nonmale het contributes 2, a male hom-alt contributes `4 - 2 = 2`, and a male het contributes `2 - 1 = 1`, i.e. half a REF allele plus half an ALT allele. `weighted_obs_ct` further down still counts that male as a full observation.

So on a file containing het haploid calls, `--freq` and `--freq counts` disagree with `--geno-counts` and `--hardy` on the same variant, and `--freq counts` emits non-integer values. Five-sample repro from #341:

```
--freq counts   ALT_CTS 2.5   OBS_CT 7
--geno-counts   HOM_REF 1  HET 1  TWO_ALT 0  HAP_REF 1  HAP_ALT 1  MISSING 1   -> 2 out of 6
--hardy         MALE_A1_CT 1  MALE_AX_CT 1                                     -> male het excluded
PLINK 1.9       C1 2  C2 4  NCHROBS 6
```

### Change

Subtract the remaining half-allele from `alt1_ct`, and drop the observation from `weighted_obs_ct`.

Male het hardcalls that carry a dosage are excluded from the correction: the existing dosage loop already removes their full hardcall contribution via `alt1_ct -= hardcall_code * sex_multiplier`, so applying the correction to them would double-subtract (and underflow `alt1_ct`, which is a `uintptr_t`). They are counted in the new `hethap_dosage_ct` inside the loop, where `sex_multiplier` and `hardcall_code` are already in hand, so there is no extra pass over the data.

Net effect: het haploid calls are treated as missing for allele-count purposes, matching `--geno-counts`, `--hardy`, the `--set-invalid-haploid-missing` result, and PLINK 1.9. Only variants that actually contain het haploid hardcalls change.

### Verification

macOS/arm64, `2.0/Makefile` dev build, compared against a binary built from `master` (22df061) on the same machine.

- `2.0/Tests/run_tests.sh`: 8/8 pass.
- **No change on valid data.** 300 samples, 400 variants, chr1 + chrX, males hemizygous on chrX, 4% missing. Output byte-identical to master for `--freq`, `--freq counts`, `--geno-counts`, `--missing`, `--hardy`, `--het`, `--sample-counts`, `--maf 0.2 --write-snplist`, `--hwe 0.001 --write-snplist`, `--pca 3 approx`, `--make-bed`, `--export vcf`, `--indep-pairwise 50 5 0.5`, plus `--keep` on a 150-sample subset and `--threads 1`.
- **Intended change on het-haploid data.** 300 samples, 400 chrX variants, 15% of male calls heterozygous:

  | command | vs master | vs `--set-invalid-haploid-missing` |
  |---|---|---|
  | `--freq counts` | differs | identical |
  | `--freq counts --keep` (150 samples) | differs | identical |
  | `--freq counts --threads 1` | differs | identical |
  | `--freq` | differs | identical |
  | `--geno-counts` | identical | identical |
  | `--hardy` | identical | identical |
  | `--maf 0.2 --write-snplist` | identical | identical |

  201 of the 400 variants had a fractional `ALT_CTS` under master; none do now.
- The 5-sample repro now gives `ALT_CTS 2, OBS_CT 6`, matching PLINK 1.9 and `--geno-counts`.
- The dosage case (`GT:DS 0/1:0.7` for a male on chrX) is unchanged by this patch and continues to match `--set-invalid-haploid-missing keep-dosage`.

### Scope

Deliberately limited to the biallelic chrX path. The multiallelic chrX path (`all_dosages[0] -= 2 * ss[0] + hethap_ct;` and the `patch_10` male ALTx/ALTy handling) and the chrY / non-XY-haploid paths half-count het haploid calls the same way; #341 describes them. I left them alone because the right semantics there are less obvious, in particular for chrMT where `--geno-counts` currently reports het haploid calls as `HET_REF_ALT_CTS` rather than missing. Happy to extend this once you say which behaviour you want.

Generated with [Claude Code](https://claude.com/claude-code)