### PR TITLE
ci: run the 2.0/Tests suite on push and pull request

### DIFF
--- a/.github/workflows/plink2_functional_tests.yml
+++ b/.github/workflows/plink2_functional_tests.yml
@@ -1,0 +1,86 @@
+name: PLINK2 functional tests
+
+# Builds PLINK 2.0 and PLINK 1.9 from this repository and runs the
+# self-contained suite in 2.0/Tests, which compares plink2 output against
+# plink 1.9 output and checks a number of round trips.
+#
+# Everything this needs (including the test data) is in the repository, so
+# unlike the weekly GLM workflow this can run on every pull request.
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '1.9/**'
+      - '2.0/**'
+      - '.github/workflows/plink2_functional_tests.yml'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '1.9/**'
+      - '2.0/**'
+      - '.github/workflows/plink2_functional_tests.yml'
+  workflow_dispatch:
+
+jobs:
+  run_tests:
+    name: 2.0/Tests on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            libopenblas-dev \
+            liblapack-dev \
+            liblapacke-dev \
+            zlib1g-dev \
+            libzstd-dev
+
+      - name: Determine parallelism
+        run: echo "NPROC=$(getconf _NPROCESSORS_ONLN)" >> "$GITHUB_ENV"
+
+      - name: Build PLINK 2.0 and pgen_compress
+        working-directory: 2.0/build_dynamic
+        run: make -j"$NPROC"
+
+      - name: Build PLINK 1.9
+        working-directory: 1.9
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            make -j"$NPROC" ZLIB=-lz BLASFLAGS="-llapack -lopenblas"
+          else
+            make -j"$NPROC" ZLIB=-lz
+          fi
+
+      - name: Put PLINK 1.9 on PATH
+        run: echo "$GITHUB_WORKSPACE/1.9" >> "$GITHUB_PATH"
+
+      - name: Report versions
+        run: |
+          plink --version
+          2.0/build_dynamic/plink2 --version
+
+      - name: Run 2.0/Tests
+        working-directory: 2.0/Tests
+        run: ./run_tests.sh "$GITHUB_WORKSPACE/2.0/build_dynamic"
+
+      - name: Upload test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: plink2-test-logs-${{ matrix.os }}
+          path: 2.0/Tests/**/*.log
+          if-no-files-found: ignore


### PR DESCRIPTION
Related to #338 and #339: as a downstream packager it would help to have the functional suite gating changes, not only running weekly.

### Why

`.github/workflows/auto_checkcommits_tests_linuxmac.yml` runs the GLM comparison batches on a weekly schedule (or manual dispatch) and needs cached external test data. Nothing runs on pull requests, and `2.0/Tests/run_tests.sh` is never exercised in CI at all.

That suite is already self-contained: the test data (including `1kg_phase3_chr21_start.vcf.gz`) is in the repository, and the PLINK 1.9 binary it compares against can be built from `1.9/` in the same tree. So it can run on every push and PR without any cache or external download.

### What

A new workflow that, on `ubuntu-latest` and `macos-latest`:

1. builds `plink2` and `pgen_compress` via `2.0/build_dynamic/Makefile`,
2. builds PLINK 1.9 from `1.9/` and puts it on `PATH`,
3. runs `2.0/Tests/run_tests.sh` against the `2.0/build_dynamic` directory,
4. uploads the per-test `.log` files as an artifact if anything fails.

Path filters restrict it to changes under `1.9/`, `2.0/`, or the workflow itself. `workflow_dispatch` is included so it can be run by hand.

The Linux job installs `libopenblas-dev liblapack-dev liblapacke-dev zlib1g-dev libzstd-dev`, and links PLINK 1.9 with `BLASFLAGS="-llapack -lopenblas"` since OpenBLAS provides the `cblas_*` symbols `1.9/plink_matrix.c` needs. Both platforms build PLINK 1.9 with `ZLIB=-lz` so the sibling `../zlib-1.3.2` source tree the Makefile expects by default is not required.

### Verification

Run on my fork, both jobs green: https://github.com/BenjaminDEMAILLE/plink-ng/actions/runs/33442214617

```
PLINK v1.9.0-b.7.11.d 64-bit (30 Mar 2026)
PLINK v2.0.0-a.7.4 64-bit (18 Aug 2026)
TEST_EXTRACT_CHR passed.
TEST_MAF_FILTER passed.
TEST_PGEN_FREQ passed.
TEST_PHASED_VCF passed.
TEST_SAMPLE_SUBSET passed.
TEST_DOSAGE_ROUND_TRIP passed.
TEST_EXPORT_OPTIONS passed.
TEST_ONE_WAY_EXPORT passed.
All tests passed.
```

About 2.5 minutes per platform, so it should not be an annoying tax on PRs. An earlier revision failed on Linux with `plink2_matrix.h:134: fatal error: lapacke.h: No such file or directory`, which is why `liblapacke-dev` is in the package list.

No program behaviour is changed by this PR; it only adds a workflow file.

Generated with [Claude Code](https://claude.com/claude-code)