### PR TITLE
Print the error messages six failure paths were composing and dropping (#345)

### DIFF
--- a/2.0/plink2.cc
+++ b/2.0/plink2.cc
@@ -8795,7 +8795,7 @@ int main(int argc, char** argv) {
           const char* mode_str = ScantokDouble(cur_modif, &dxx);
           if (unlikely((!mode_str) || (dxx < 0.0) || (dxx > 2147483646.0))) {
             snprintf(g_logbuf, kLogbufSize, "Error: Invalid --mac argument '%s'.\n", cur_modif);
-            goto main_ret_INVALID_CMDLINE;
+            goto main_ret_INVALID_CMDLINE_WWA;
           }
           if (dxx > 0.0) {
             // round up, but keep as much precision as possible

--- a/2.0/plink2_export.cc
+++ b/2.0/plink2_export.cc
@@ -7645,7 +7645,7 @@ PglErr ExportBcf(const uintptr_t* sample_include, const uint32_t* sample_include
           if (unlikely(*closing_gt != '>')) {
             *idval_end = '\0';
             snprintf(g_logbuf, kLogbufSize, "Error: %s:%s header line in .pvar file doesn't end with '>'.\n", is_info_line? "INFO" : "FILTER", idval);
-            goto ExportBcf_ret_MALFORMED_INPUT;
+            goto ExportBcf_ret_MALFORMED_INPUT_WW;
           }
           uint32_t cur_idx;
           reterr = AddToFifHtable(g_bigstack_base, idval, fif_keys_htable_size, id_slen, prechar, &tmp_alloc_end, fif_keys_mutable, fif_keys_htable, &fif_key_ct, &cur_idx);

--- a/2.0/plink2_import.cc
+++ b/2.0/plink2_import.cc
@@ -17025,7 +17025,7 @@ PglErr EigSnpToPvar(const char* snpname, const ChrInfo* cip, const char* missing
       double cur_cm;
       if (unlikely(!ScantokDouble(cm_start, &cur_cm))) {
         snprintf(g_logbuf, kLogbufSize, "Error: Invalid centimorgan position on line %" PRIuPTR " of .snp file.\n", line_idx);
-        goto EigSnpToPvar_ret_MALFORMED_INPUT;
+        goto EigSnpToPvar_ret_MALFORMED_INPUT_WW;
       }
       if (cur_cm != 0.0) {
         at_least_one_nzero_cm = 1;
@@ -17183,6 +17183,9 @@ PglErr EigSnpToPvar(const char* snpname, const ChrInfo* cip, const char* missing
     break;
   EigSnpToPvar_ret_MISSING_TOKENS:
     logerrprintfww("Error: Line %" PRIuPTR " of %s has fewer tokens than expected.\n", line_idx, snpname);
+  EigSnpToPvar_ret_MALFORMED_INPUT_WW:
+    WordWrapB(0);
+    logerrputsb();
   EigSnpToPvar_ret_MALFORMED_INPUT:
     reterr = kPglRetMalformedInput;
     break;

--- a/2.0/plink2_import_legacy.cc
+++ b/2.0/plink2_import_legacy.cc
@@ -1322,6 +1322,8 @@ PglErr TpedToPgen(const char* tpedname, const char* tfamname, const char* missin
     reterr = kPglRetInconsistentInput;
     break;
   TpedToPgen_ret_DEGENERATE_DATA:
+    WordWrapB(0);
+    logerrputsb();
     reterr = kPglRetDegenerateData;
     break;
   }
@@ -2397,6 +2399,8 @@ PglErr PedmapToPgen(const char* pedname, const char* mapname, const char* missin
     reterr = kPglRetInconsistentInput;
     break;
   PedmapToPgen_ret_DEGENERATE_DATA:
+    WordWrapB(0);
+    logerrputsb();
     reterr = kPglRetDegenerateData;
     break;
   }

--- a/2.0/plink2_misc.cc
+++ b/2.0/plink2_misc.cc
@@ -349,6 +349,8 @@ PglErr UpdateVarBps(const ChrInfo* cip, const char* const* variant_ids, const ui
     reterr = kPglRetInconsistentInput;
     break;
   UpdateVarBps_ret_MALFORMED_INPUT:
+    WordWrapB(0);
+    logerrputsb();
     reterr = kPglRetMalformedInput;
     break;
   }


### PR DESCRIPTION
Fixes #345.

Six sites compose a message into `g_logbuf` and then `goto` a label that only assigns `reterr`, so the run exits nonzero with **nothing on stderr**.

```c
snprintf(g_logbuf, kLogbufSize, "Error: ...");
goto Foo_ret_MALFORMED_INPUT;
...
Foo_ret_MALFORMED_INPUT:
  reterr = kPglRetMalformedInput;   // g_logbuf never printed
  break;
```

`--mac` is the one users are most likely to hit: an unparseable command-line argument aborts the run with no explanation.

```
$ plink2 --bfile base --mac notanumber --make-bed --out m1 2>err.txt >out.txt
$ echo $?; wc -c err.txt
8
       0 err.txt
```

### Approach

- `--mac` and `--export bcf` already had a printing `_WW` sibling label in the same function, so the `goto` is simply redirected to it.
- `EigSnpToPvar_ret_MALFORMED_INPUT` has seven other callers that print their own messages first, so it gets a new `EigSnpToPvar_ret_MALFORMED_INPUT_WW`.
- The other three labels each had exactly one caller, so they print directly. Adding `_WW` siblings there produced `-Wunused-label` warnings, which is why they are handled this way.

### Verification

macOS/arm64, `2.0/Makefile` dev build. All six reproduce on `master` (22df061) and print after the patch, with exit codes unchanged:

| trigger | exit | after |
|---|---:|---|
| `--mac notanumber` | 8 | `Error: Invalid --mac argument 'notanumber'.` |
| `--update-map` with non-numeric bp | 6 | `Error: Invalid bp coordinate on line 1 of --update-map file.` |
| `--tfile` with empty .tped | 13 | `Error: e.tped is empty.` |
| `--pedmap` with empty .ped | 13 | `Error: e.ped is empty.` |
| `--eigfile` with non-numeric cm in .snp | 6 | `Error: Invalid centimorgan position on line 2 of .snp file.` |
| `--export bcf`, `##INFO` line missing `>` | 6 | `Error: INFO:FOO header line in .pvar file doesn't end with '>'.` |

`2.0/Tests/run_tests.sh` passes 8/8, unchanged from the pre-patch baseline. Build is warning-free.

I scanned every `.cc` under `2.0/` for `snprintf(g_logbuf, ...)` immediately followed by a `goto` whose label body contains no `logerrputsb`/`logerrprintf`/`WordWrapB`; these six were the only hits, so this should be the complete set.

Generated with [Claude Code](https://claude.com/claude-code)