### PR TITLE
Add --fisher (allelic case/control exact test)

### DIFF
--- a/2.0/include/plink2_stats.cc
+++ b/2.0/include/plink2_stats.cc
@@ -1968,6 +1968,104 @@ double HweLnP(int32_t obs_hets, int32_t obs_hom1, int32_t obs_hom2, int32_t midp
 // constant to be compatible with them doesn't cost us anything.)
 static const double kExactTestBias = k2m50 / (1LL << 33);
 
+// 2^{-40}; matches PLINK 1.9's FISHER_EPSILON.
+static const double kFisherEpsilon = 0.0000000000009094947017729282379150390625;
+
+double FisherExact2x2(uint32_t m11, uint32_t m12, uint32_t m21, uint32_t m22, uint32_t midp) {
+  // Two-sided Fisher's exact test on a 2x2 contingency table, ported from
+  // PLINK 1.9's fisher22().  Sums the likelihoods of all tables at least as
+  // extreme as the observed one, relative to the observed table's likelihood.
+  // With midp, half the probability mass of the tables tied with the observed
+  // one is subtracted.
+  double tprob = (1 - kFisherEpsilon) * kExactTestBias;
+  double cur_prob = tprob;
+  double cprob = 0.0;
+  int32_t tie_ct = 1;
+  // Ensure we are left of the distribution center, m11 <= m22, and m12 <= m21.
+  if (m12 > m21) {
+    const uint32_t uii = m12;
+    m12 = m21;
+    m21 = uii;
+  }
+  if (m11 > m22) {
+    const uint32_t uii = m11;
+    m11 = m22;
+    m22 = uii;
+  }
+  if ((S_CAST(uint64_t, m11) * m22) > (S_CAST(uint64_t, m12) * m21)) {
+    uint32_t uii = m11;
+    m11 = m12;
+    m12 = uii;
+    uii = m21;
+    m21 = m22;
+    m22 = uii;
+  }
+  double cur11 = m11;
+  double cur12 = m12;
+  double cur21 = m21;
+  double cur22 = m22;
+  while (cur12 > 0.5) {
+    cur11 += 1;
+    cur22 += 1;
+    cur_prob *= (cur12 * cur21) / (cur11 * cur22);
+    cur12 -= 1;
+    cur21 -= 1;
+    if (cur_prob > DBL_MAX) {
+      // overflowed to +inf
+      return 0;
+    }
+    if (cur_prob < kExactTestBias) {
+      if (cur_prob > (1 - 2 * kFisherEpsilon) * kExactTestBias) {
+        ++tie_ct;
+      }
+      tprob += cur_prob;
+      break;
+    }
+    cprob += cur_prob;
+  }
+  if ((cprob == 0) && (!midp)) {
+    return 1;
+  }
+  while (cur12 > 0.5) {
+    cur11 += 1;
+    cur22 += 1;
+    cur_prob *= (cur12 * cur21) / (cur11 * cur22);
+    cur12 -= 1;
+    cur21 -= 1;
+    const double preaddp = tprob;
+    tprob += cur_prob;
+    if (tprob <= preaddp) {
+      break;
+    }
+  }
+  if (m11) {
+    cur11 = m11;
+    cur12 = m12;
+    cur21 = m21;
+    cur22 = m22;
+    cur_prob = (1 - kFisherEpsilon) * kExactTestBias;
+    do {
+      cur12 += 1;
+      cur21 += 1;
+      cur_prob *= (cur11 * cur22) / (cur12 * cur21);
+      cur11 -= 1;
+      cur22 -= 1;
+      const double preaddp = tprob;
+      tprob += cur_prob;
+      if (tprob <= preaddp) {
+        if (!midp) {
+          return preaddp / (cprob + preaddp);
+        }
+        return (preaddp - ((1 - kFisherEpsilon) * kExactTestBias * 0.5) * tie_ct) / (cprob + preaddp);
+      }
+    } while (cur11 > 0.5);
+  }
+  if (!midp) {
+    return tprob / (cprob + tprob);
+  }
+  return (tprob - ((1 - kFisherEpsilon) * kExactTestBias * 0.5) * tie_ct) / (cprob + tprob);
+}
+
 uint32_t HweThresh(int32_t obs_hets, int32_t obs_hom1, int32_t obs_hom2, double pval_thresh) {
   // Threshold-test-only version of HweLnP() which is usually able to exit
   // from the calculation earlier.  Assumes DBL_MIN <= pval_thresh <= 1 (note

--- a/2.0/include/plink2_stats.h
+++ b/2.0/include/plink2_stats.h
@@ -69,6 +69,10 @@ double HweLnP(int32_t obs_hets, int32_t obs_hom1, int32_t obs_hom2, int32_t midp
 // the big picture; instead, the best way to manage result instability after
 // the beta 1 release is to just set a high bar for making any more behavior
 // changes.
+// Two-sided Fisher's exact test on a 2x2 contingency table.  Set midp to use
+// the mid-p adjustment.
+double FisherExact2x2(uint32_t m11, uint32_t m12, uint32_t m21, uint32_t m22, uint32_t midp);
+
 uint32_t HweThresh(int32_t obs_hets, int32_t obs_hom1, int32_t obs_hom2, double pval_thresh);
 
 uint32_t HweThreshMidp(int32_t obs_hets, int32_t obs_hom1, int32_t obs_hom2, double pval_thresh);

--- a/2.0/plink2.cc
+++ b/2.0/plink2.cc
@@ -224,7 +224,8 @@ FLAGSET64_DEF_START()
   kfCommand1Vcor = (1 << 29),
   kfCommand1PhenoSvd = (1 << 30),
   kfCommand1CheckOrImputeSex = (1U << 31),
-  kfCommand1MendelReport = (1LLU << 32)
+  kfCommand1MendelReport = (1LLU << 32),
+  kfCommand1Fisher = (1LLU << 33)
 FLAGSET64_DEF_END(Command1Flags);
 
 void PgenInfoPrint(const char* pgenname, const PgenFileInfo* pgfip, PgenExtensionLl* header_exts, PgenHeaderCtrl header_ctrl, uint32_t max_allele_ct) {
@@ -397,6 +398,7 @@ typedef struct Plink2CmdlineStruct {
   MissingRptFlags missing_rpt_flags;
   GenoCountsFlags geno_counts_flags;
   HardyFlags hardy_flags;
+  FisherFlags fisher_flags;
   HetFlags het_flags;
   SampleCountsFlags sample_counts_flags;
   RecoverVarIdsFlags recover_var_ids_flags;
@@ -552,7 +554,7 @@ typedef struct Plink2CmdlineStruct {
 
 // er, probably time to just always initialize this...
 uint32_t SingleVariantLoaderIsNeeded(const char* king_cutoff_fprefix, Command1Flags command_flags1, MakePlink2Flags make_plink2_flags, RmDupMode rmdup_mode, double hwe_ln_thresh) {
-  return (command_flags1 & (kfCommand1Exportf | kfCommand1MakeKing | kfCommand1GenoCounts | kfCommand1LdPrune | kfCommand1Validate | kfCommand1Pca | kfCommand1MakeRel | kfCommand1Glm | kfCommand1Score | kfCommand1Ld | kfCommand1Hardy | kfCommand1Sdiff | kfCommand1PgenDiff | kfCommand1Clump | kfCommand1Vcor)) ||
+  return (command_flags1 & (kfCommand1Exportf | kfCommand1MakeKing | kfCommand1GenoCounts | kfCommand1LdPrune | kfCommand1Validate | kfCommand1Pca | kfCommand1MakeRel | kfCommand1Glm | kfCommand1Score | kfCommand1Ld | kfCommand1Hardy | kfCommand1Sdiff | kfCommand1PgenDiff | kfCommand1Clump | kfCommand1Vcor | kfCommand1Fisher)) ||
     ((command_flags1 & kfCommand1MakePlink2) && (make_plink2_flags & kfMakePgen)) ||
     ((command_flags1 & kfCommand1KingCutoff) && (!king_cutoff_fprefix)) ||
     (rmdup_mode != kRmDup0) ||
@@ -572,7 +574,7 @@ uint32_t DecentAlleleFreqsAreNeeded(Command1Flags command_flags1, CheckSexFlags 
 // variants are retained, but let's keep this simpler for now
 uint32_t MajAllelesAreNeeded(Command1Flags command_flags1, PcaFlags pca_flags, GlmFlags glm_flags, VcorFlags vcor_flags) {
   // Keep this in sync with --error-on-freq-calc.
-  return (command_flags1 & (kfCommand1LdPrune | kfCommand1Ld)) ||
+  return (command_flags1 & (kfCommand1LdPrune | kfCommand1Ld | kfCommand1Fisher)) ||
     ((command_flags1 & kfCommand1Pca) && (pca_flags & kfPcaBiallelicVarWts)) ||
     ((command_flags1 & kfCommand1Glm) && (!(glm_flags & kfGlmOmitRef))) ||
     ((command_flags1 & kfCommand1Vcor) && ((!(vcor_flags & kfVcorRefBased)) || (vcor_flags & (kfVcorColMaj | kfVcorColNonmaj))));
@@ -2962,6 +2964,13 @@ PglErr Plink2Core(const Plink2Cmdline* pcp, MakePlink2Flags make_plink2_flags, c
         }
       }
 
+      if (pcp->command_flags1 & kfCommand1Fisher) {
+        reterr = FisherReport(sample_include, pheno_cols, pheno_names, variant_include, cip, variant_bps, variant_ids, allele_idx_offsets, allele_storage, maj_alleles, raw_sample_ct, pheno_ct, max_pheno_name_blen, raw_variant_ct, variant_ct, max_allele_slen, pcp->fisher_flags, &simple_pgr, outname, outname_end);
+        if (unlikely(reterr)) {
+          goto Plink2Core_ret_1;
+        }
+      }
+
       if (pcp->command_flags1 & kfCommand1Fst) {
         reterr = FstReport(sample_include, sex_male, pheno_cols, pheno_names, variant_include, cip, variant_bps, variant_ids, allele_idx_offsets, allele_storage, &(pcp->fst_info), raw_sample_ct, pheno_ct, max_pheno_name_blen, raw_variant_ct, variant_ct, max_allele_ct, pcp->max_thread_ct, pgr_alloc_cacheline_ct, &pgfi, outname, outname_end);
         if (unlikely(reterr)) {
@@ -3969,6 +3978,7 @@ int main(int argc, char** argv) {
     pc.missing_rpt_flags = kfMissingRpt0;
     pc.geno_counts_flags = kfGenoCounts0;
     pc.hardy_flags = kfHardy0;
+    pc.fisher_flags = kfFisher0;
     pc.het_flags = kfHet0;
     pc.sample_counts_flags = kfSampleCounts0;
     pc.recover_var_ids_flags = kfRecoverVarIds0;
@@ -6119,7 +6129,37 @@ int main(int argc, char** argv) {
         break;
 
       case 'f':
-        if (strequal_k_unsafe(flagname_p2, "req")) {
+        if (strequal_k_unsafe(flagname_p2, "isher")) {
+          if (unlikely(EnforceParamCtRange(argvk[arg_idx], param_ct, 0, 3))) {
+            goto main_ret_INVALID_CMDLINE_2A;
+          }
+          for (uint32_t param_idx = 1; param_idx <= param_ct; ++param_idx) {
+            const char* cur_modif = argvk[arg_idx + param_idx];
+            const uint32_t cur_modif_slen = strlen(cur_modif);
+            if (strequal_k(cur_modif, "zs", cur_modif_slen)) {
+              pc.fisher_flags |= kfFisherZs;
+            } else if (strequal_k(cur_modif, "midp", cur_modif_slen)) {
+              pc.fisher_flags |= kfFisherMidp;
+            } else if (likely(StrStartsWith(cur_modif, "cols=", cur_modif_slen))) {
+              if (unlikely(pc.fisher_flags & kfFisherColAll)) {
+                logerrputs("Error: Multiple --fisher cols= modifiers.\n");
+                goto main_ret_INVALID_CMDLINE;
+              }
+              reterr = ParseColDescriptor(&(cur_modif[5]), "chrom\0pos\0ref\0alt\0a1\0counts\0freq\0nobs\0or\0p\0", "fisher", kfFisherColChrom, kfFisherColDefault, 1, &pc.fisher_flags);
+              if (unlikely(reterr)) {
+                goto main_ret_1;
+              }
+            } else {
+              snprintf(g_logbuf, kLogbufSize, "Error: Invalid --fisher argument '%s'.\n", cur_modif);
+              goto main_ret_INVALID_CMDLINE_WWA;
+            }
+          }
+          if (!(pc.fisher_flags & kfFisherColAll)) {
+            pc.fisher_flags |= kfFisherColDefault;
+          }
+          pc.command_flags1 |= kfCommand1Fisher;
+          pc.dependency_flags |= kfFilterAllReq;
+        } else if (strequal_k_unsafe(flagname_p2, "req")) {
           if (unlikely(EnforceParamCtRange(argvk[arg_idx], param_ct, 0, 5))) {
             goto main_ret_INVALID_CMDLINE_2A;
           }

--- a/2.0/plink2_help.cc
+++ b/2.0/plink2_help.cc
@@ -815,6 +815,28 @@ PglErr DispHelp(const char* const* argvk, uint32_t param_ct) {
 "    maybefid/fid/maybesid/sid to the .imendel output file; and\n"
 "    chrom/pos/ref/alt to the .lmendel[.zst] output file.\n\n"
               );
+    HelpPrint("fisher\0", &help_ctrl, 1,
+"  --fisher ['zs'] ['midp'] ['cols='<column set descriptor>]\n"
+"    Allelic case/control association via Fisher's exact test, i.e. what PLINK\n"
+"    1.9's \"--assoc fisher\" reported.  --glm covers the asymptotic and Firth\n"
+"    cases; this is the exact test.\n"
+"    * A1 is the minor allele, as in PLINK 1.9.\n"
+"    * 'midp' applies the mid-p adjustment.\n"
+"    * Only autosomal biallelic variants are analyzed.\n"
+"    Supported column sets are:\n"
+"      chrom: Chromosome ID.\n"
+"      pos: Base-pair coordinate.\n"
+"      (ID is always present, and positioned here.)\n"
+"      ref: Reference allele.\n"
+"      alt: Alternate allele.\n"
+"      a1: Tested (minor) allele.\n"
+"      counts: A1/A2 allele counts in cases and controls.\n"
+"      freq: A1 frequency in cases and in controls.\n"
+"      nobs: Number of allele observations.\n"
+"      or: Odds ratio.\n"
+"      p: Fisher's exact test p-value.\n"
+"    The default is chrom,pos,ref,alt,a1,freq,nobs,or,p.\n\n"
+              );
     HelpPrint("het\0", &help_ctrl, 1,
 "  --het ['zs'] ['small-sample'] ['cols='<column set descriptor>]\n"
 "    Inbreeding coefficient report.  Supports multiallelic variants.\n"

--- a/2.0/plink2_misc.cc
+++ b/2.0/plink2_misc.cc
@@ -10374,6 +10374,308 @@ PglErr HetCalcMain(const uintptr_t* sample_include, const uintptr_t* variant_sub
   return reterr;
 }
 
+// Allelic case/control association via Fisher's exact test, i.e. what PLINK
+// 1.9's "--assoc fisher" reported.  --glm covers the asymptotic and Firth
+// cases, but not the exact test, which is what rare-variant case/control
+// analyses generally want.
+PglErr FisherReport(const uintptr_t* orig_sample_include, const PhenoCol* pheno_cols, const char* pheno_names, const uintptr_t* variant_include, const ChrInfo* cip, const uint32_t* variant_bps, const char* const* variant_ids, const uintptr_t* allele_idx_offsets, const char* const* allele_storage, const AlleleCode* maj_alleles, uint32_t raw_sample_ct, uint32_t pheno_ct, uintptr_t max_pheno_name_blen, uint32_t raw_variant_ct, uint32_t variant_ct, uint32_t max_allele_slen, FisherFlags flags, PgenReader* simple_pgrp, char* outname, char* outname_end) {
+  unsigned char* bigstack_mark = g_bigstack_base;
+  char* cswritep = nullptr;
+  CompressStreamState css;
+  PreinitCstream(&css);
+  PglErr reterr = kPglRetSuccess;
+  {
+    // Exactly one case/control phenotype must be selected; --fisher writes a
+    // single file, so silently picking one of several would be a trap.
+    uint32_t pheno_idx = UINT32_MAX;
+    uint32_t cc_pheno_ct = 0;
+    for (uint32_t uii = 0; uii != pheno_ct; ++uii) {
+      if (pheno_cols[uii].type_code == kPhenoDtypeCc) {
+        if (!cc_pheno_ct) {
+          pheno_idx = uii;
+        }
+        ++cc_pheno_ct;
+      }
+    }
+    if (unlikely(!cc_pheno_ct)) {
+      logerrputs("Error: --fisher requires a case/control phenotype.\n");
+      goto FisherReport_ret_INCONSISTENT_INPUT;
+    }
+    if (unlikely(cc_pheno_ct > 1)) {
+      logerrputs("Error: --fisher requires exactly one case/control phenotype; use --pheno-name\nto select one.\n");
+      goto FisherReport_ret_INCONSISTENT_INPUT;
+    }
+    const PhenoCol* cur_pheno_col = &(pheno_cols[pheno_idx]);
+    const char* cur_pheno_name = &(pheno_names[pheno_idx * max_pheno_name_blen]);
+
+    const uint32_t raw_sample_ctl = BitCtToWordCt(raw_sample_ct);
+    uintptr_t* sample_include;
+    if (unlikely(bigstack_alloc_w(raw_sample_ctl, &sample_include))) {
+      goto FisherReport_ret_NOMEM;
+    }
+    BitvecAndCopy(orig_sample_include, cur_pheno_col->nonmiss, raw_sample_ctl, sample_include);
+    const uint32_t sample_ct = PopcountWords(sample_include, raw_sample_ctl);
+    if (unlikely(sample_ct < 2)) {
+      logerrputs("Error: --fisher requires at least two samples with a nonmissing phenotype.\n");
+      goto FisherReport_ret_INCONSISTENT_INPUT;
+    }
+    const uint32_t sample_ctl = BitCtToWordCt(sample_ct);
+    const uint32_t sample_ctv = BitCtToVecCt(sample_ct);
+    uint32_t* sample_include_cumulative_popcounts;
+    uintptr_t* genovec;
+    uintptr_t* case_collapsed;
+    uintptr_t* case_interleaved;
+    uintptr_t* ctrl_collapsed;
+    uintptr_t* ctrl_interleaved;
+    if (unlikely(bigstack_alloc_u32(raw_sample_ctl, &sample_include_cumulative_popcounts) ||
+                 bigstack_alloc_w(NypCtToWordCt(raw_sample_ct), &genovec) ||
+                 bigstack_alloc_w(sample_ctv * kWordsPerVec, &case_collapsed) ||
+                 bigstack_alloc_w(sample_ctv * kWordsPerVec, &case_interleaved) ||
+                 bigstack_alloc_w(sample_ctv * kWordsPerVec, &ctrl_collapsed) ||
+                 bigstack_alloc_w(sample_ctv * kWordsPerVec, &ctrl_interleaved))) {
+      goto FisherReport_ret_NOMEM;
+    }
+    FillCumulativePopcounts(sample_include, raw_sample_ctl, sample_include_cumulative_popcounts);
+    const uint32_t sample_ctaw = sample_ctv * kWordsPerVec;
+    ZeroWArr(sample_ctaw, case_collapsed);
+    ZeroWArr(sample_ctaw, ctrl_collapsed);
+    CopyBitarrSubset(cur_pheno_col->data.cc, sample_include, sample_ct, case_collapsed);
+    ZeroTrailingBits(sample_ct, case_collapsed);
+    BitvecInvertCopy(case_collapsed, sample_ctl, ctrl_collapsed);
+    ZeroTrailingBits(sample_ct, ctrl_collapsed);
+    const uint32_t case_ct = PopcountWords(case_collapsed, sample_ctl);
+    const uint32_t ctrl_ct = sample_ct - case_ct;
+    if (unlikely((!case_ct) || (!ctrl_ct))) {
+      logerrprintfww("Error: --fisher requires both cases and controls (phenotype '%s' has %u case%s and %u control%s).\n", cur_pheno_name, case_ct, (case_ct == 1)? "" : "s", ctrl_ct, (ctrl_ct == 1)? "" : "s");
+      goto FisherReport_ret_INCONSISTENT_INPUT;
+    }
+    FillInterleavedMaskVec(case_collapsed, sample_ctv, case_interleaved);
+    FillInterleavedMaskVec(ctrl_collapsed, sample_ctv, ctrl_interleaved);
+
+    // chrX and the haploid chromosomes need male-haploid allele counting and a
+    // decision about het haploid calls; rather than guess at PLINK 1.9's
+    // conventions there, restrict to autosomes as --het and --ibc do.
+    const uintptr_t* autosomal_variant_include = variant_include;
+    uint32_t autosomal_variant_ct = variant_ct;
+    reterr = ConditionalAllocateNonAutosomalVariants(cip, "--fisher", raw_variant_ct, &autosomal_variant_include, &autosomal_variant_ct);
+    if (unlikely(reterr)) {
+      goto FisherReport_ret_1;
+    }
+    if (unlikely(!autosomal_variant_ct)) {
+      logerrputs("Error: --fisher requires at least one autosomal variant.\n");
+      goto FisherReport_ret_INCONSISTENT_INPUT;
+    }
+
+    const uint32_t midp = (flags / kfFisherMidp) & 1;
+    const uint32_t output_zst = flags & kfFisherZs;
+    OutnameZstSet(".fisher", output_zst, outname_end);
+    reterr = InitCstreamAlloc(outname, 0, output_zst, 1, kCompressStreamBlock + 2 * kMaxIdSlen + 512 + 2 * max_allele_slen, &css, &cswritep);
+    if (unlikely(reterr)) {
+      goto FisherReport_ret_1;
+    }
+    const uint32_t chr_col = flags & kfFisherColChrom;
+    const uint32_t pos_col = flags & kfFisherColPos;
+    const uint32_t ref_col = flags & kfFisherColRef;
+    const uint32_t alt_col = flags & kfFisherColAlt;
+    const uint32_t a1_col = flags & kfFisherColA1;
+    const uint32_t cts_col = flags & kfFisherColCounts;
+    const uint32_t freq_col = flags & kfFisherColFreq;
+    const uint32_t nobs_col = flags & kfFisherColNobs;
+    const uint32_t or_col = flags & kfFisherColOr;
+    const uint32_t p_col = flags & kfFisherColP;
+    *cswritep++ = '#';
+    if (chr_col) {
+      cswritep = strcpya_k(cswritep, "CHROM\t");
+    }
+    if (pos_col) {
+      cswritep = strcpya_k(cswritep, "POS\t");
+    }
+    cswritep = strcpya_k(cswritep, "ID");
+    if (ref_col) {
+      cswritep = strcpya_k(cswritep, "\tREF");
+    }
+    if (alt_col) {
+      cswritep = strcpya_k(cswritep, "\tALT");
+    }
+    if (a1_col) {
+      cswritep = strcpya_k(cswritep, "\tA1");
+    }
+    if (cts_col) {
+      cswritep = strcpya_k(cswritep, "\tA1_CASE_CT\tA2_CASE_CT\tA1_CTRL_CT\tA2_CTRL_CT");
+    }
+    if (freq_col) {
+      cswritep = strcpya_k(cswritep, "\tA1_CASE_FREQ\tA1_CTRL_FREQ");
+    }
+    if (nobs_col) {
+      cswritep = strcpya_k(cswritep, "\tOBS_CT");
+    }
+    if (or_col) {
+      cswritep = strcpya_k(cswritep, "\tOR");
+    }
+    if (p_col) {
+      if (midp) {
+        cswritep = strcpya_k(cswritep, "\tMIDP");
+      } else {
+        cswritep = strcpya_k(cswritep, "\tP");
+      }
+    }
+    AppendBinaryEoln(&cswritep);
+
+    PgrSampleSubsetIndex pssi;
+    PgrSetSampleSubsetIndex(sample_include_cumulative_popcounts, simple_pgrp, &pssi);
+    uintptr_t variant_uidx_base = 0;
+    uintptr_t cur_bits = autosomal_variant_include[0];
+    uint32_t chr_fo_idx = UINT32_MAX;
+    uint32_t chr_end = 0;
+    uint32_t chr_buf_blen = 0;
+    char* chr_buf = nullptr;
+    if (chr_col) {
+      if (unlikely(bigstack_alloc_c(kMaxIdSlen, &chr_buf))) {
+        goto FisherReport_ret_NOMEM;
+      }
+    }
+    uint32_t allele_ct = 2;
+    uint32_t skipped_ct = 0;
+    uint32_t reported_ct = 0;
+    STD_ARRAY_DECL(uint32_t, 4, case_genocounts);
+    STD_ARRAY_DECL(uint32_t, 4, ctrl_genocounts);
+    for (uint32_t variant_idx = 0; variant_idx != autosomal_variant_ct; ++variant_idx) {
+      const uint32_t variant_uidx = BitIter1(autosomal_variant_include, &variant_uidx_base, &cur_bits);
+      if (chr_col && (variant_uidx >= chr_end)) {
+        do {
+          ++chr_fo_idx;
+          chr_end = cip->chr_fo_vidx_start[chr_fo_idx + 1];
+        } while (variant_uidx >= chr_end);
+        char* chr_name_end = chrtoa(cip, cip->chr_file_order[chr_fo_idx], chr_buf);
+        *chr_name_end = '\t';
+        chr_buf_blen = 1 + S_CAST(uintptr_t, chr_name_end - chr_buf);
+      }
+      uintptr_t allele_idx_offset_base = 2 * variant_uidx;
+      if (allele_idx_offsets) {
+        allele_idx_offset_base = allele_idx_offsets[variant_uidx];
+        allele_ct = allele_idx_offsets[variant_uidx + 1] - allele_idx_offset_base;
+      }
+      if (allele_ct != 2) {
+        // Fisher's exact test here is defined on a 2x2 table.
+        ++skipped_ct;
+        continue;
+      }
+      reterr = PgrGet(sample_include, pssi, sample_ct, variant_uidx, simple_pgrp, genovec);
+      if (unlikely(reterr)) {
+        PgenErrPrintNV(reterr, variant_uidx);
+        goto FisherReport_ret_1;
+      }
+      ZeroTrailingNyps(sample_ct, genovec);
+      GenoarrCountSubsetFreqs(genovec, case_interleaved, sample_ct, case_ct, case_genocounts);
+      GenoarrCountSubsetFreqs(genovec, ctrl_interleaved, sample_ct, ctrl_ct, ctrl_genocounts);
+      // genocounts[0] = hom REF, [1] = het, [2] = hom ALT, [3] = missing
+      const uint32_t case_ref_ct = 2 * case_genocounts[0] + case_genocounts[1];
+      const uint32_t case_alt_ct = 2 * case_genocounts[2] + case_genocounts[1];
+      const uint32_t ctrl_ref_ct = 2 * ctrl_genocounts[0] + ctrl_genocounts[1];
+      const uint32_t ctrl_alt_ct = 2 * ctrl_genocounts[2] + ctrl_genocounts[1];
+
+      // A1 is the minor allele, as in PLINK 1.9's --assoc.
+      const uint32_t a1_is_alt = (maj_alleles[variant_uidx] == 0);
+      const uint32_t a1_case_ct = a1_is_alt? case_alt_ct : case_ref_ct;
+      const uint32_t a2_case_ct = a1_is_alt? case_ref_ct : case_alt_ct;
+      const uint32_t a1_ctrl_ct = a1_is_alt? ctrl_alt_ct : ctrl_ref_ct;
+      const uint32_t a2_ctrl_ct = a1_is_alt? ctrl_ref_ct : ctrl_alt_ct;
+
+      if (chr_col) {
+        cswritep = memcpya(cswritep, chr_buf, chr_buf_blen);
+      }
+      if (pos_col) {
+        cswritep = u32toa_x(variant_bps[variant_uidx], '\t', cswritep);
+      }
+      cswritep = strcpya(cswritep, variant_ids[variant_uidx]);
+      if (ref_col) {
+        *cswritep++ = '\t';
+        cswritep = strcpya(cswritep, allele_storage[allele_idx_offset_base]);
+      }
+      if (alt_col) {
+        *cswritep++ = '\t';
+        cswritep = strcpya(cswritep, allele_storage[allele_idx_offset_base + 1]);
+      }
+      if (a1_col) {
+        *cswritep++ = '\t';
+        cswritep = strcpya(cswritep, allele_storage[allele_idx_offset_base + a1_is_alt]);
+      }
+      if (cts_col) {
+        *cswritep++ = '\t';
+        cswritep = u32toa_x(a1_case_ct, '\t', cswritep);
+        cswritep = u32toa_x(a2_case_ct, '\t', cswritep);
+        cswritep = u32toa_x(a1_ctrl_ct, '\t', cswritep);
+        cswritep = u32toa(a2_ctrl_ct, cswritep);
+      }
+      const uint32_t case_obs = a1_case_ct + a2_case_ct;
+      const uint32_t ctrl_obs = a1_ctrl_ct + a2_ctrl_ct;
+      if (freq_col) {
+        *cswritep++ = '\t';
+        if (case_obs) {
+          cswritep = dtoa_g(u31tod(a1_case_ct) / u31tod(case_obs), cswritep);
+        } else {
+          cswritep = strcpya_k(cswritep, "NA");
+        }
+        *cswritep++ = '\t';
+        if (ctrl_obs) {
+          cswritep = dtoa_g(u31tod(a1_ctrl_ct) / u31tod(ctrl_obs), cswritep);
+        } else {
+          cswritep = strcpya_k(cswritep, "NA");
+        }
+      }
+      if (nobs_col) {
+        *cswritep++ = '\t';
+        cswritep = u32toa(case_obs + ctrl_obs, cswritep);
+      }
+      if (or_col) {
+        *cswritep++ = '\t';
+        const uint64_t numer = S_CAST(uint64_t, a1_case_ct) * a2_ctrl_ct;
+        const uint64_t denom = S_CAST(uint64_t, a2_case_ct) * a1_ctrl_ct;
+        if (denom && numer) {
+          cswritep = dtoa_g(S_CAST(double, numer) / S_CAST(double, denom), cswritep);
+        } else {
+          cswritep = strcpya_k(cswritep, "NA");
+        }
+      }
+      if (p_col) {
+        *cswritep++ = '\t';
+        if (case_obs && ctrl_obs) {
+          cswritep = dtoa_g(FisherExact2x2(a1_case_ct, a2_case_ct, a1_ctrl_ct, a2_ctrl_ct, midp), cswritep);
+        } else {
+          cswritep = strcpya_k(cswritep, "NA");
+        }
+      }
+      AppendBinaryEoln(&cswritep);
+      if (unlikely(Cswrite(&css, &cswritep))) {
+        goto FisherReport_ret_WRITE_FAIL;
+      }
+      ++reported_ct;
+    }
+    if (unlikely(CswriteCloseNull(&css, cswritep))) {
+      goto FisherReport_ret_WRITE_FAIL;
+    }
+    if (skipped_ct) {
+      logprintf("--fisher: %u multiallelic variant%s skipped.\n", skipped_ct, (skipped_ct == 1)? "" : "s");
+    }
+    logprintfww("--fisher (%s): %u case%s and %u control%s, %u variant%s written to %s .\n", cur_pheno_name, case_ct, (case_ct == 1)? "" : "s", ctrl_ct, (ctrl_ct == 1)? "" : "s", reported_ct, (reported_ct == 1)? "" : "s", outname);
+  }
+  while (0) {
+  FisherReport_ret_NOMEM:
+    reterr = kPglRetNomem;
+    break;
+  FisherReport_ret_WRITE_FAIL:
+    reterr = kPglRetWriteFail;
+    break;
+  FisherReport_ret_INCONSISTENT_INPUT:
+    reterr = kPglRetInconsistentInput;
+    break;
+  }
+ FisherReport_ret_1:
+  CswriteCloseCond(&css, cswritep);
+  BigstackReset(bigstack_mark);
+  return reterr;
+}
+
 PglErr HetReport(const uintptr_t* sample_include, const SampleIdInfo* siip, const uintptr_t* orig_variant_include, const ChrInfo* cip, const uintptr_t* allele_idx_offsets, const double* allele_freqs, const uintptr_t* founder_info, uint32_t raw_sample_ct, uint32_t sample_ct, uint32_t founder_ct, uint32_t raw_variant_ct, uint32_t orig_variant_ct, uint32_t max_allele_ct, HetFlags flags, uint32_t max_thread_ct, uintptr_t pgr_alloc_cacheline_ct, PgenFileInfo* pgfip, char* outname, char* outname_end) {
   unsigned char* bigstack_mark = g_bigstack_base;
   char* cswritep = nullptr;

--- a/2.0/plink2_misc.h
+++ b/2.0/plink2_misc.h
@@ -226,6 +226,25 @@ FLAGSET_DEF_START()
   kfHetColAll = ((kfHetColF * 2) - kfHetColMaybefid)
 FLAGSET_DEF_END(HetFlags);
 
+FLAGSET_DEF_START()
+  kfFisher0,
+  kfFisherZs = (1 << 0),
+  kfFisherMidp = (1 << 1),
+
+  kfFisherColChrom = (1 << 2),
+  kfFisherColPos = (1 << 3),
+  kfFisherColRef = (1 << 4),
+  kfFisherColAlt = (1 << 5),
+  kfFisherColA1 = (1 << 6),
+  kfFisherColCounts = (1 << 7),
+  kfFisherColFreq = (1 << 8),
+  kfFisherColNobs = (1 << 9),
+  kfFisherColOr = (1 << 10),
+  kfFisherColP = (1 << 11),
+  kfFisherColDefault = (kfFisherColChrom | kfFisherColPos | kfFisherColRef | kfFisherColAlt | kfFisherColA1 | kfFisherColFreq | kfFisherColNobs | kfFisherColOr | kfFisherColP),
+  kfFisherColAll = ((kfFisherColP * 2) - kfFisherColChrom)
+FLAGSET_DEF_END(FisherFlags);
+
 typedef struct UpdateAllelesStruct {
   NONCOPYABLE(UpdateAllelesStruct);
   UpdateAllelesFlags flags;
@@ -470,6 +489,8 @@ PglErr Sdiff(const uintptr_t* orig_sample_include, const SampleIdInfo* siip, con
 PglErr WriteSnplist(const uintptr_t* variant_include, const char* const* variant_ids, uint32_t variant_ct, uint32_t output_zst, uint32_t allow_dups, uint32_t max_thread_ct, char* outname, char* outname_end);
 
 PglErr WriteCovar(const uintptr_t* sample_include, const PedigreeIdInfo* piip, const uintptr_t* sex_nm, const uintptr_t* sex_male, const PhenoCol* pheno_cols, const char* pheno_names, const PhenoCol* covar_cols, const char* covar_names, const uint32_t* new_sample_idx_to_old, const char* output_missing_pheno, uint32_t sample_ct, uint32_t pheno_ct, uintptr_t max_pheno_name_blen, uint32_t covar_ct, uintptr_t max_covar_name_blen, WriteCovarFlags write_covar_flags, char* outname, char* outname_end);
+
+PglErr FisherReport(const uintptr_t* orig_sample_include, const PhenoCol* pheno_cols, const char* pheno_names, const uintptr_t* variant_include, const ChrInfo* cip, const uint32_t* variant_bps, const char* const* variant_ids, const uintptr_t* allele_idx_offsets, const char* const* allele_storage, const AlleleCode* maj_alleles, uint32_t raw_sample_ct, uint32_t pheno_ct, uintptr_t max_pheno_name_blen, uint32_t raw_variant_ct, uint32_t variant_ct, uint32_t max_allele_slen, FisherFlags flags, PgenReader* simple_pgrp, char* outname, char* outname_end);
 
 PglErr HetReport(const uintptr_t* sample_include, const SampleIdInfo* siip, const uintptr_t* orig_variant_include, const ChrInfo* cip, const uintptr_t* allele_idx_offsets, const double* allele_freqs, const uintptr_t* founder_info, uint32_t raw_sample_ct, uint32_t sample_ct, uint32_t founder_ct, uint32_t raw_variant_ct, uint32_t orig_variant_ct, uint32_t max_allele_ct, HetFlags flags, uint32_t max_thread_ct, uintptr_t pgr_alloc_cacheline_ct, PgenFileInfo* pgfip, char* outname, char* outname_end);
 


### PR DESCRIPTION
From the parity audit in #344.

**Up front:** this reintroduces functionality from `--assoc`, which you deliberately retired in favour of `--glm`. My argument for it is narrow: `--glm` covers the asymptotic and Firth cases, but not the *exact* test, and that is what rare-variant case/control analyses generally want. If you would rather expose Fisher's exact test through a different surface, the `FisherExact2x2()` half of this PR stands on its own and the command half can be dropped.

### Two parts

**1. `FisherExact2x2()`** in `include/plink2_stats.cc`, a port of 1.9's `fisher22()` reusing the existing `kExactTestBias` constant. Plain and mid-p variants.

**2. `--fisher ['zs'] ['midp'] ['cols='<...>]`**, writing `<out>.fisher`. A1 is the minor allele, as in 1.9. Column sets: `chrom`, `pos`, `ref`, `alt`, `a1`, `counts`, `freq`, `nobs`, `or`, `p`.

### Scope decisions

- **Autosomal biallelic variants only.** chrX and the haploid chromosomes need male-haploid allele counting plus a decision about het haploid calls. Rather than guess at 1.9's conventions there, `--fisher` restricts itself the way `--het` and `--ibc` do. On a mixed-chromosome fileset, 1.9 reports 2500 variants and `--fisher` reports the 1800 autosomal ones, with identical counts on all 1800. Happy to extend this if you tell me which chrX model you want.
- **Exactly one case/control phenotype**, since `--fisher` writes a single file. With more than one it asks for `--pheno-name` rather than silently picking one.

### Verification

macOS/arm64, against `PLINK v1.9.0-b.7.11`.

**The statistic itself.** I compiled 1.9's `fisher22()` and my port into one binary and compared them directly over **400,000 random 2x2 tables** (both `midp` settings, entries up to 100,000):

```
tables=400000  max relative diff=0  mismatches=0
```

Bit-identical, not merely close.

**End to end.** Since the p-value function is bit-identical, the remaining question is whether the allele counts feeding it match. Compared against `--assoc fisher counts`, which prints integer counts:

| dataset | result |
|---|---|
| 1000 samples x 1800 autosomal variants | A1 identical, **integer allele counts identical on every variant**, P and OR agree to 1.9's 4-significant-digit print precision (max rel. diff 4.6e-4) |
| same, `midp` vs `--assoc fisher-midp` | identical counts, same agreement |
| 2504 real 1000 Genomes chr21 samples, 600 variants | A1 identical, **allele counts identical**, max rel. dP 3.6e-4, max rel. dOR 4.3e-4 |
| mixed-chromosome fileset | all 1800 autosomal variants match exactly; the 700 non-autosomal ones are absent by design |

The residual p-value differences are entirely 1.9's output rounding: the counts are equal integers and the function is bit-identical, so the underlying doubles must be too.

`--keep` subsets, `zs`, `cols=` subsetting, and the error paths (no case/control phenotype, two case/control phenotypes, a subset with no controls, bad column name) all behave as intended. Output is byte-identical to a `master` build for `--het`, `--freq`, `--hardy`, `--make-bed`, `--glm` and `--indep-pairwise`. `2.0/Tests/run_tests.sh` passes 8/8; build is warning-free.

Generated with [Claude Code](https://claude.com/claude-code)