### PR TITLE
Implement --tag-mode2

### DIFF
--- a/2.0/Tests/TEST_SHOW_TAGS/run_tests.sh
+++ b/2.0/Tests/TEST_SHOW_TAGS/run_tests.sh
@@ -38,14 +38,29 @@ diff -q plink19_la.tags plink2_la.tags
 awk -f compare_list.awk plink19_la.tags.list plink2_la.tags.list
 test "$(grep -vc '^#' plink2_la.tags.list)" -eq "$(wc -l < tmp_targets.txt)"
 
-# 4. The result must not depend on --threads.
+# 4. --tag-mode2: a two-column target file, and a two-column .tags file
+#    covering every retained variant.
+awk '{print $1 "\t" ((NR % 3 == 0)? 1 : ((NR % 3 == 1)? 0 : 2))}' tmp_targets.txt > tmp_mode2_targets.txt
+awk '!/^#/ {print $3 "\t0"}' tmp_h.vcf | head -n 40 >> tmp_mode2_targets.txt
+plink --bfile tmp_data --show-tags tmp_mode2_targets.txt --tag-mode2 --out plink19_m2
+$1/plink2 $2 $3 --bfile tmp_data --show-tags tmp_mode2_targets.txt --tag-mode2 --out plink2_m2
+diff -q plink19_m2.tags plink2_m2.tags
+test "$(wc -l < plink2_m2.tags)" -eq "$(grep -vc '^#' tmp_data.bim)"
+
+# 4b. --tag-mode2 has no meaning with "--show-tags all".
+if $1/plink2 $2 $3 --bfile tmp_data --show-tags all --tag-mode2 --out plink2_m2bad 2> tmp_m2_err.txt; then
+    echo "--tag-mode2 unexpectedly accepted with \"--show-tags all\""
+    exit 1
+fi
+
+# 5. The result must not depend on --threads.
 for t in 1 3 8
 do
     $1/plink2 $2 $3 --bfile tmp_data --show-tags all --threads $t --out plink2_t$t
     diff -q plink2_all.tags.list plink2_t$t.tags.list
 done
 
-# 5. 'zs' is the same report, compressed.
+# 6. 'zs' is the same report, compressed.
 $1/plink2 $2 $3 --bfile tmp_data --show-tags all zs --out plink2_zs
 $1/plink2 $2 $3 --zst-decompress plink2_zs.tags.list.zst > plink2_zs.tags.list
 diff -q plink2_all.tags.list plink2_zs.tags.list

--- a/2.0/plink2.cc
+++ b/2.0/plink2.cc
@@ -3109,7 +3109,7 @@ PglErr Plink2Core(const Plink2Cmdline* pcp, MakePlink2Flags make_plink2_flags, c
           logerrputs("Error: --show-tags requires a sorted .pvar/.bim.  Retry this command after\nusing --make-pgen/--make-bed + --sort-vars to sort your data.\n");
           return kPglRetInconsistentInput;
         }
-        reterr = ShowTags(variant_include, cip, variant_bps, variant_ids, maj_alleles, founder_info, pcp->tag_info.tag_fname, pcp->tag_info.list_all, pcp->tag_info.bp_radius, pcp->tag_info.r2_thresh, raw_variant_ct, raw_sample_ct, founder_ct, max_variant_id_slen, pcp->tag_info.output_zst, pcp->max_thread_ct, &simple_pgr, outname, outname_end);
+        reterr = ShowTags(variant_include, cip, variant_bps, variant_ids, maj_alleles, founder_info, pcp->tag_info.tag_fname, pcp->tag_info.list_all, pcp->tag_info.mode2, pcp->tag_info.bp_radius, pcp->tag_info.r2_thresh, raw_variant_ct, variant_ct, raw_sample_ct, founder_ct, max_variant_id_slen, pcp->tag_info.output_zst, pcp->max_thread_ct, &simple_pgr, outname, outname_end);
         if (unlikely(reterr)) {
           goto Plink2Core_ret_1;
         }
@@ -12885,6 +12885,11 @@ int main(int argc, char** argv) {
             goto main_ret_INVALID_CMDLINE_WWA;
           }
           pc.tag_info.bp_radius = S_CAST(int32_t, dxx * 1000 * (1 + kSmallEpsilon));
+        } else if (strequal_k_unsafe(flagname_p2, "ag-mode2")) {
+          if (unlikely(EnforceParamCtRange(argvk[arg_idx], param_ct, 0, 0))) {
+            goto main_ret_INVALID_CMDLINE_2A;
+          }
+          pc.tag_info.mode2 = 1;
         } else if (strequal_k_unsafe(flagname_p2, "ag-r2")) {
           if (unlikely(EnforceParamCtRange(argvk[arg_idx], param_ct, 1, 1))) {
             goto main_ret_INVALID_CMDLINE_2A;
@@ -13792,6 +13797,16 @@ int main(int argc, char** argv) {
     if (unlikely(pc.tag_info.list_all && (!(pc.command_flags1 & kfCommand1ShowTags)))) {
       logerrputs("Error: --list-all must be used with --show-tags.\n");
       goto main_ret_INVALID_CMDLINE_A;
+    }
+    if (pc.tag_info.mode2) {
+      if (unlikely(!(pc.command_flags1 & kfCommand1ShowTags))) {
+        logerrputs("Error: --tag-mode2 must be used with --show-tags.\n");
+        goto main_ret_INVALID_CMDLINE_A;
+      }
+      if (unlikely(!pc.tag_info.tag_fname)) {
+        logerrputs("Error: --tag-mode2 cannot be used with \"--show-tags all\".\n");
+        goto main_ret_INVALID_CMDLINE_A;
+      }
     }
     if (!outname_end) {
       outname_end = &(outname[6]);

--- a/2.0/plink2_help.cc
+++ b/2.0/plink2_help.cc
@@ -3142,9 +3142,14 @@ PglErr DispHelp(const char* const* argvk, uint32_t param_ct) {
 "                         (same syntax as --snps), and --ld-snp-list specifies a\n"
 "                         file to load variant IDs from.\n"
               );
-    HelpPrint("tag-kb\0tag-r2\0show-tags\0", &help_ctrl, 0,
+    HelpPrint("tag-kb\0tag-r2\0tag-mode2\0show-tags\0", &help_ctrl, 0,
 "  --tag-kb <kbs>       : Set --show-tags max tag kb distance (default 250).\n"
 "  --tag-r2 <val>       : Set --show-tags min tag r^2 (default 0.8).\n"
+"  --tag-mode2          : Make --show-tags read a two-column file, treating only\n"
+"                         the variants whose second column is '1' as targets,\n"
+"                         and write a .tags file in the same two-column form\n"
+"                         covering every variant.  Cannot be used with\n"
+"                         \"--show-tags all\".\n"
               );
     // todo: add citation for 2018 KING update paper, which should discuss the
     // two-stage screen + refine workflow supported by --king-table-subset,

--- a/2.0/plink2_ld.cc
+++ b/2.0/plink2_ld.cc
@@ -13462,6 +13462,7 @@ void CleanupTwolocus(TwolocusInfo* tlip) {
 void InitTag(TagInfo* tip) {
   tip->tag_fname = nullptr;
   tip->list_all = 0;
+  tip->mode2 = 0;
   tip->bp_radius = 250000;
   tip->output_zst = 0;
   tip->r2_thresh = 0.8;
@@ -13535,7 +13536,7 @@ static double TagPairR2(const TagCtx* ctx, uint32_t slot0, uint32_t slot1) {
   return cov12 * cov12 / (variance1 * variance2);
 }
 
-PglErr ShowTags(const uintptr_t* orig_variant_include, const ChrInfo* cip, const uint32_t* variant_bps, const char* const* variant_ids, const AlleleCode* maj_alleles, const uintptr_t* founder_info, const char* tag_fname, uint32_t list_all, uint32_t bp_radius, double r2_thresh, uint32_t raw_variant_ct, uint32_t raw_sample_ct, uint32_t founder_ct, uint32_t max_variant_id_slen, uint32_t output_zst, uint32_t max_thread_ct, PgenReader* simple_pgrp, char* outname, char* outname_end) {
+PglErr ShowTags(const uintptr_t* orig_variant_include, const ChrInfo* cip, const uint32_t* variant_bps, const char* const* variant_ids, const AlleleCode* maj_alleles, const uintptr_t* founder_info, const char* tag_fname, uint32_t list_all, uint32_t mode2, uint32_t bp_radius, double r2_thresh, uint32_t raw_variant_ct, uint32_t variant_ct, uint32_t raw_sample_ct, uint32_t founder_ct, uint32_t max_variant_id_slen, uint32_t output_zst, uint32_t max_thread_ct, PgenReader* simple_pgrp, char* outname, char* outname_end) {
   unsigned char* bigstack_mark = g_bigstack_base;
   char* cswritep = nullptr;
   CompressStreamState css;
@@ -13620,6 +13621,14 @@ PglErr ShowTags(const uintptr_t* orig_variant_include, const ChrInfo* cip, const
         }
         const char* token_end = CurTokenEnd(line_start);
         const uint32_t id_slen = token_end - line_start;
+        if (mode2) {
+          // Two-column input; a variant is a target only when its second
+          // column is exactly "1".  PLINK 1.x ignores every other line.
+          const char* second_token = FirstNonTspace(token_end);
+          if ((*second_token != '1') || (!IsSpaceOrEoln(second_token[1]))) {
+            continue;
+          }
+        }
         uint32_t llidx;
         const uint32_t variant_uidx = VariantIdDupHtableFind(line_start, variant_ids, variant_id_htable, htable_dup_base, id_slen, variant_id_htable_size, max_variant_id_slen, &llidx);
         if (variant_uidx == UINT32_MAX) {
@@ -13849,15 +13858,30 @@ PglErr ShowTags(const uintptr_t* orig_variant_include, const ChrInfo* cip, const
       if (unlikely(reterr)) {
         goto ShowTags_ret_1;
       }
-      uintptr_t tag_uidx_base = 0;
-      uintptr_t tag_bits = tagging_variants[0];
       const uint32_t tagging_ct = PopcountWords(tagging_variants, raw_variant_ctl);
-      for (uint32_t uii = 0; uii != tagging_ct; ++uii) {
-        const uint32_t cur_uidx = BitIter1(tagging_variants, &tag_uidx_base, &tag_bits);
-        cswritep = strcpya(cswritep, variant_ids[cur_uidx]);
-        AppendBinaryEoln(&cswritep);
-        if (unlikely(Cswrite(&css, &cswritep))) {
-          goto ShowTags_ret_WRITE_FAIL;
+      if (!mode2) {
+        uintptr_t tag_uidx_base = 0;
+        uintptr_t tag_bits = tagging_variants[0];
+        for (uint32_t uii = 0; uii != tagging_ct; ++uii) {
+          const uint32_t cur_uidx = BitIter1(tagging_variants, &tag_uidx_base, &tag_bits);
+          cswritep = strcpya(cswritep, variant_ids[cur_uidx]);
+          AppendBinaryEoln(&cswritep);
+          if (unlikely(Cswrite(&css, &cswritep))) {
+            goto ShowTags_ret_WRITE_FAIL;
+          }
+        }
+      } else {
+        // Every retained variant is listed, with a 0/1 membership column.
+        uintptr_t out_uidx_base = 0;
+        uintptr_t out_bits = orig_variant_include[0];
+        for (uint32_t vidx = 0; vidx != variant_ct; ++vidx) {
+          const uint32_t variant_uidx = BitIter1(orig_variant_include, &out_uidx_base, &out_bits);
+          cswritep = strcpyax(cswritep, variant_ids[variant_uidx], '\t');
+          *cswritep++ = '0' + IsSet(tagging_variants, variant_uidx);
+          AppendBinaryEoln(&cswritep);
+          if (unlikely(Cswrite(&css, &cswritep))) {
+            goto ShowTags_ret_WRITE_FAIL;
+          }
         }
       }
       if (unlikely(CswriteCloseNull(&css, cswritep))) {

--- a/2.0/plink2_ld.h
+++ b/2.0/plink2_ld.h
@@ -196,6 +196,7 @@ typedef struct TagInfoStruct {
   NONCOPYABLE(TagInfoStruct);
   char* tag_fname;   // nullptr in 'all' mode
   uint32_t list_all;
+  uint32_t mode2;
   uint32_t bp_radius;
   uint32_t output_zst;
   double r2_thresh;
@@ -267,7 +268,7 @@ PglErr LdConsole(const uintptr_t* variant_include, const ChrInfo* cip, const cha
 
 PglErr ClumpReports(const uintptr_t* orig_variant_include, const ChrInfo* cip, const uint32_t* variant_bps, const char* const* variant_ids, const uintptr_t* allele_idx_offsets, const char* const* allele_storage, const uintptr_t* founder_info, const uintptr_t* sex_nm, const uintptr_t* sex_male, const ClumpInfo* clump_ip, uint32_t raw_variant_ct, uint32_t orig_variant_ct, uint32_t raw_sample_ct, uint32_t founder_ct, uint32_t nosex_ct, uint32_t max_variant_id_slen, uint32_t max_allele_slen, double output_min_ln, uint32_t max_thread_ct, uintptr_t pgr_alloc_cacheline_ct, PgenFileInfo* pgfip, PgenReader* simple_pgrp, char* outname, char* outname_end);
 
-PglErr ShowTags(const uintptr_t* orig_variant_include, const ChrInfo* cip, const uint32_t* variant_bps, const char* const* variant_ids, const AlleleCode* maj_alleles, const uintptr_t* founder_info, const char* tag_fname, uint32_t list_all, uint32_t bp_radius, double r2_thresh, uint32_t raw_variant_ct, uint32_t raw_sample_ct, uint32_t founder_ct, uint32_t max_variant_id_slen, uint32_t output_zst, uint32_t max_thread_ct, PgenReader* simple_pgrp, char* outname, char* outname_end);
+PglErr ShowTags(const uintptr_t* orig_variant_include, const ChrInfo* cip, const uint32_t* variant_bps, const char* const* variant_ids, const AlleleCode* maj_alleles, const uintptr_t* founder_info, const char* tag_fname, uint32_t list_all, uint32_t mode2, uint32_t bp_radius, double r2_thresh, uint32_t raw_variant_ct, uint32_t variant_ct, uint32_t raw_sample_ct, uint32_t founder_ct, uint32_t max_variant_id_slen, uint32_t output_zst, uint32_t max_thread_ct, PgenReader* simple_pgrp, char* outname, char* outname_end);
 
 PglErr TwolocusReport(const uintptr_t* sample_include, const uintptr_t* variant_include, const char* const* variant_ids, const uintptr_t* allele_idx_offsets, const char* const* allele_storage, const char* mkr1, const char* mkr2, uint32_t raw_sample_ct, uint32_t sample_ct, uint32_t variant_ct, uint32_t max_allele_slen, uint32_t max_thread_ct, PgenReader* simple_pgrp, char* outname, char* outname_end);
 


### PR DESCRIPTION
Adds PLINK 1.x's `--tag-mode2` on top of #372.

It changes both ends of `--show-tags` file mode:

- **Input**: the file is read as two columns, and only variants whose second column is exactly `1` become targets. Lines carrying anything else are ignored rather than rejected, matching PLINK 1.x (whose "fewer tokens than expected" error is unreachable, since a one-token line just fails the `'1'` test).
- **Output**: `.tags` lists every retained variant with a tab and a `0`/`1` membership column, instead of listing only the tagging variants.

Rejected with `--show-tags all`, which has no input file to reinterpret. Both that check and the `--show-tags` requirement run after the parse loop, since flags are handled in alphabetical order and `--tag-mode2` sorts first.

## Verification

Byte-identical to PLINK 1.9 across 9 `--tag-kb` x `--tag-r2` combinations on a 200-variant, 400-sample set with real haplotype block structure, where the tag count ranges from 11 (only the targets themselves) to 110. Also checked with `--list-all`, and on a file mixing `1`, `0` and `2` in the second column to confirm the non-`1` rows are dropped the same way.

Plain `--show-tags` output, in both file and `all` mode, is unchanged.

**Stacked on #372.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)