### PR TITLE
PLINK 1.9: --hwe keeps variants whose exact p is at or above the threshold when the observed tail is complete before the other tail is walked

### DIFF
--- a/1.9/plink_stats.c
+++ b/1.9/plink_stats.c
@@ -478,6 +478,13 @@ int32_t SNPHWE_t(int32_t obs_hets, int32_t obs_hom1, int32_t obs_hom2, double th
     if (tailp1 + tail2_ceil < exit_thresh) {
       return 1;
     }
+    // The tail containing the observed count is complete here when the
+    // partial-sum loop above was skipped (obs_hets < 4 / obs_homr <= 1); check
+    // it against the threshold before walking the other tail, since that
+    // loop only compares after adding an element and may not iterate at all.
+    if (tailp1 + tailp2 >= exit_thresh) {
+      return 0;
+    }
     exit_threshx = exit_thresh - tailp1;
     while (curr_hets_t2 > 1) {
       curr_homr_t2 += 1;
@@ -550,6 +557,13 @@ int32_t SNPHWE_t(int32_t obs_hets, int32_t obs_hom1, int32_t obs_hom2, double th
     }
     if (tailp1 + tail2_ceil < exit_thresh) {
       return 1;
+    }
+    // The tail containing the observed count is complete here when the
+    // partial-sum loop above was skipped (obs_hets < 4 / obs_homr <= 1); check
+    // it against the threshold before walking the other tail, since that
+    // loop only compares after adding an element and may not iterate at all.
+    if (tailp1 + tailp2 >= exit_thresh) {
+      return 0;
     }
     exit_threshx = exit_thresh - tailp1;
     while (curr_homr_t2 > 0.5) {
@@ -671,6 +685,13 @@ int32_t SNPHWE_midp_t(int32_t obs_hets, int32_t obs_hom1, int32_t obs_hom2, doub
     if (tailp1 + tail2_ceil < exit_thresh) {
       return 1;
     }
+    // The tail containing the observed count is complete here when the
+    // partial-sum loop above was skipped (obs_hets < 4 / obs_homr <= 1); check
+    // it against the threshold before walking the other tail, since that
+    // loop only compares after adding an element and may not iterate at all.
+    if (tailp1 + tailp2 >= exit_thresh) {
+      return 0;
+    }
     exit_threshx = exit_thresh - tailp1;
     while (curr_hets_t2 > 1) {
       curr_homr_t2 += 1;
@@ -747,6 +768,13 @@ int32_t SNPHWE_midp_t(int32_t obs_hets, int32_t obs_hom1, int32_t obs_hom2, doub
     }
     if (tailp1 + tail2_ceil < exit_thresh) {
       return 1;
+    }
+    // The tail containing the observed count is complete here when the
+    // partial-sum loop above was skipped (obs_hets < 4 / obs_homr <= 1); check
+    // it against the threshold before walking the other tail, since that
+    // loop only compares after adding an element and may not iterate at all.
+    if (tailp1 + tailp2 >= exit_thresh) {
+      return 0;
     }
     exit_threshx = exit_thresh - tailp1;
     while (curr_homr_t2 > 0.5) {


### PR DESCRIPTION
Fixes #380.

`SNPHWE_t()` and `SNPHWE_midp_t()` in `1.9/plink_stats.c` extend the tail that contains the observed heterozygote count by one element and then, for `obs_hets < 4` (lower tail) or `obs_homr <= 1` (upper tail), skip the loop that compares the running tail sum with the pass threshold. The only comparison left is inside the loop over the other tail, which compares after adding an element and does not iterate when that tail has at most one element — always the case with two heterozygotes — so the function falls through to `return 1` and `--hwe` removes a variant whose p-value is above the threshold (the filter effectively tests `p − P(hets − 2) < threshold`). `--hardy` uses `SNPHWE2()` and prints the correct p, so the two disagree: a variant with `--hardy` P = 0.4805 is removed by `--hwe 0.48`.

This patch adds the missing comparison before the other tail is walked, at the four sites (both tail branches of both functions). 28 added lines, no other behaviour change.

Verification (harnesses linked in the issue):
- driving the shipped functions over every genotype table with n ≤ 200 and ≤ 6 heterozygotes and bisecting the flip threshold: 19,399 of 67,883 tables flipped below their exact p before the patch (all 2-het tables, 9,600 of 9,697 3-het tables), 0 after, for both `SNPHWE_t` and `SNPHWE_midp_t`;
- the issue's reproduction passes; `--hwe 0.4806` still removes the variant;
- `--hwe` at 0.05, 1e-3 and 1e-6 with and without `midp` on 400 random variants (3 % missing calls, 60 pushed out of HWE) keeps exactly the variants with exact p ≥ threshold before and after;
- `1.9/tests/tests.py` does not reach this code and needs a PLINK 1.07 build, so no test file is added; the reproduction script in the issue is the regression check.

Found in a source-level correctness audit of research software (methods and harnesses: https://github.com/cindykrafft/research-software-audit/tree/main/audits/plink)

---
_Generated by [Claude Code](https://claude.ai/code)_