### PR TITLE
Add --mgf (BIMBAM mean genotype import)

### DIFF
--- a/2.0/Tests/TEST_MGF/.gitignore
+++ b/2.0/Tests/TEST_MGF/.gitignore
@@ -1,0 +1,4 @@
+plink19*
+plink2*
+tmp_*
+*.log

--- a/2.0/Tests/TEST_MGF/run_tests.sh
+++ b/2.0/Tests/TEST_MGF/run_tests.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+# "--mgf", the BIMBAM mean genotype reader, checked as the inverse of
+# "--export mgf".
+
+set -exo pipefail
+
+BUILD=$1
+EXTRA1=$2
+EXTRA2=$3
+
+# 1. Hardcalls.  A round trip through the text format has to reproduce the
+#    .mgf and .pos.txt byte for byte, and the .pvar apart from its header.
+plink --simulate simulate.txt --simulate-missing 0.03 --simulate-ncases 60 --simulate-ncontrols 60 --out tmp_hard > /dev/null
+$BUILD/plink2 $EXTRA1 $EXTRA2 --bfile tmp_hard --export mgf --out tmp_hard_e
+$BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_hard_e.mgf tmp_hard_e.pos.txt --out tmp_hard_r
+$BUILD/plink2 $EXTRA1 $EXTRA2 --pfile tmp_hard_r --export mgf --out tmp_hard_e2
+diff -q tmp_hard_e.mgf tmp_hard_e2.mgf
+diff -q tmp_hard_e.pos.txt tmp_hard_e2.pos.txt
+
+# The .pvar has to name the same variants at the same positions, with REF and
+# ALT on the same sides: the .mgf's dosages count its second column, which is
+# ALT, so a swap here would silently invert every call.
+$BUILD/plink2 $EXTRA1 $EXTRA2 --bfile tmp_hard --make-just-pvar --out tmp_hard_p
+diff -q <(grep -v '^#' tmp_hard_p.pvar) <(grep -v '^#' tmp_hard_r.pvar)
+
+# Sample IDs are not in the format, so they are synthesized as with --dummy.
+diff -q <(printf '#IID\n'; seq 0 119 | sed 's/^/per/') tmp_hard_r.psam
+
+# 2. Dosages.  --export mgf writes five significant digits, so a second trip
+#    through it is exact even though the first one rounds.
+$BUILD/plink2 $EXTRA1 $EXTRA2 --dummy 120 400 0.03 dosage-freq=0.7 --seed 1 --out tmp_dose
+$BUILD/plink2 $EXTRA1 $EXTRA2 --pfile tmp_dose --export mgf --out tmp_dose_e
+$BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_dose_e.mgf tmp_dose_e.pos.txt --out tmp_dose_r
+$BUILD/plink2 $EXTRA1 $EXTRA2 --pfile tmp_dose_r --export mgf --out tmp_dose_e2
+diff -q tmp_dose_e.mgf tmp_dose_e2.mgf
+# The fixture has to actually exercise the dosage path.
+grep -q '\.' tmp_dose_e.mgf
+
+# 3. Commas are separators in both files, and 'NA', '-9', '?', '??' and '.'
+#    all mark a missing call.
+tr '\t' ',' < tmp_dose_e.mgf > tmp_comma.mgf
+tr '\t' ',' < tmp_dose_e.pos.txt > tmp_comma.pos.txt
+$BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_comma.mgf tmp_comma.pos.txt --out tmp_comma_r
+$BUILD/plink2 $EXTRA1 $EXTRA2 --pfile tmp_comma_r --export mgf --out tmp_comma_e
+diff -q tmp_dose_e.mgf tmp_comma_e.mgf
+
+for code in -9 '?' '??' '.'; do
+    sed "s/\bNA\b/${code}/g" tmp_dose_e.mgf > tmp_miss.mgf
+    $BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_miss.mgf tmp_dose_e.pos.txt --out tmp_miss_r
+    $BUILD/plink2 $EXTRA1 $EXTRA2 --pfile tmp_miss_r --export mgf --out tmp_miss_e
+    diff -q tmp_dose_e.mgf tmp_miss_e.mgf
+done
+
+# 4. 'pheno=' loads one row per sample; the columns become PHENO1, PHENO2, ...
+awk 'BEGIN {print "#IID\tqt1\tqt2"; for (i = 0; i < 120; ++i) {print "per" i "\t" (i / 8) "\t" (120 - i)}}' > tmp_pheno.txt
+$BUILD/plink2 $EXTRA1 $EXTRA2 --pfile tmp_dose --pheno tmp_pheno.txt --export mgf --out tmp_ph_e
+test -s tmp_ph_e.pheno.txt
+$BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_ph_e.mgf tmp_ph_e.pos.txt pheno=tmp_ph_e.pheno.txt --out tmp_ph_r
+head -n 1 tmp_ph_r.psam | grep -q '^#IID	PHENO1	PHENO2$'
+diff -q <(cut -f 2- tmp_ph_r.psam | tail -n +2) tmp_ph_e.pheno.txt
+
+# Without 'pheno=' there are no phenotype columns at all.
+head -n 1 tmp_dose_r.psam | grep -q '^#IID$'
+
+# 5. A block-gzipped .mgf reads back the same as the plain one.
+$BUILD/plink2 $EXTRA1 $EXTRA2 --pfile tmp_dose --export mgf bgz --out tmp_bgz
+$BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_bgz.mgf.gz tmp_bgz.pos.txt --out tmp_bgz_r
+$BUILD/plink2 $EXTRA1 $EXTRA2 --pfile tmp_bgz_r --export mgf --out tmp_bgz_e
+diff -q tmp_dose_e.mgf tmp_bgz_e.mgf
+
+# 6. Malformed input has to be rejected, naming the offending line.
+fails_with() {
+    local expected=$1
+    shift
+    if "$@" > /dev/null 2> tmp_err.txt; then
+        echo "expected failure: $*"
+        exit 1
+    fi
+    # Error messages are word-wrapped, so the newlines have to come out before
+    # a phrase can be matched across them.
+    tr '\n' ' ' < tmp_err.txt | tr -s ' ' | grep -q "$expected"
+}
+
+# A variant with no position.
+head -n 3 tmp_hard_e.pos.txt > tmp_short.pos.txt
+fails_with "line 4 of tmp_hard_e.mgf is absent from tmp_short.pos.txt" \
+    $BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_hard_e.mgf tmp_short.pos.txt --out tmp_bad1
+
+# A dosage that is neither a number in [0, 2] nor a missing code.  Reading it
+# as missing would quietly drop data.
+awk 'NR == 2 {$5 = "xyz"} {print}' OFS='\t' tmp_hard_e.mgf > tmp_badtok.mgf
+fails_with "Invalid dosage 'xyz' on line 2" \
+    $BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_badtok.mgf tmp_hard_e.pos.txt --out tmp_bad2
+awk 'NR == 3 {$6 = "2.5"} {print}' OFS='\t' tmp_hard_e.mgf > tmp_badrange.mgf
+fails_with "Invalid dosage '2.5' on line 3" \
+    $BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_badrange.mgf tmp_hard_e.pos.txt --out tmp_bad3
+
+# A row with the wrong number of samples.
+awk 'NR == 5 {NF = NF - 1} {print}' OFS='\t' tmp_hard_e.mgf > tmp_ragged.mgf
+fails_with "Line 5 of tmp_ragged.mgf" \
+    $BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_ragged.mgf tmp_hard_e.pos.txt --out tmp_bad4
+
+# A phenotype file whose length disagrees with the .mgf.
+head -n 5 tmp_ph_e.pheno.txt > tmp_short.pheno.txt
+fails_with "5 rows, while tmp_ph_e.mgf implies 120 samples" \
+    $BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_ph_e.mgf tmp_ph_e.pos.txt pheno=tmp_short.pheno.txt --out tmp_bad5
+
+# A duplicate ID in the position file, which would make the lookup ambiguous.
+{ cat tmp_hard_e.pos.txt; head -n 1 tmp_hard_e.pos.txt; } > tmp_dup.pos.txt
+fails_with "Duplicate variant ID" \
+    $BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_hard_e.mgf tmp_dup.pos.txt --out tmp_bad6

--- a/2.0/Tests/TEST_MGF/run_tests.sh
+++ b/2.0/Tests/TEST_MGF/run_tests.sh
@@ -94,7 +94,24 @@ diff -q <(cut -f 2 tmp_ids2.psam | tail -n +2) <(seq 0 119 | sed 's/^/s/')
 head -n 6 tmp_real.psam > tmp_short.psam
 fails_with "tmp_short.psam has 5 samples, while tmp_dose_e.mgf implies 120" \
     $BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_dose_e.mgf tmp_dose_e.pos.txt --psam tmp_short.psam --out tmp_bad7
-fails_with "cannot be used with --psam/--fam" \
+# --psam/--fam and 'pheno=' can be combined, as long as the sample file does
+# not carry phenotype data of its own.  A .psam need not have a phenotype
+# column at all, and a .fam's may be entirely missing.
+awk 'BEGIN {print "#IID\tSEX"; for (i = 0; i < 120; ++i) {print "s" i "\t" (i % 2 + 1)}}' > tmp_nopheno.psam
+$BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_ph_e.mgf tmp_ph_e.pos.txt pheno=tmp_ph_e.pheno.txt --psam tmp_nopheno.psam --out tmp_both
+head -n 1 tmp_both.psam | grep -qx '#IID	SEX	PHENO1	PHENO2'
+# IDs and sex from the .psam, phenotypes from the pheno= file.
+diff -q <(cut -f 1,2 tmp_both.psam | tail -n +2) <(tail -n +2 tmp_nopheno.psam)
+diff -q <(cut -f 3,4 tmp_both.psam | tail -n +2) tmp_ph_e.pheno.txt
+
+# An all-missing .fam phenotype column is not phenotype data either.
+awk 'BEGIN {for (i = 0; i < 120; ++i) {print "f" i, "s" i, 0, 0, (i % 2 + 1), -9}}' > tmp_nopheno.fam
+$BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_ph_e.mgf tmp_ph_e.pos.txt pheno=tmp_ph_e.pheno.txt --fam tmp_nopheno.fam --out tmp_bothfam
+head -n 1 tmp_bothfam.psam | grep -qx '#FID	IID	SEX	PHENO1	PHENO2'
+diff -q <(cut -f 4,5 tmp_bothfam.psam | tail -n +2) tmp_ph_e.pheno.txt
+
+# A .psam that does carry phenotypes is a genuine conflict.
+fails_with "tmp_real.psam contains phenotype data" \
     $BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_ph_e.mgf tmp_ph_e.pos.txt pheno=tmp_ph_e.pheno.txt --psam tmp_real.psam --out tmp_bad8
 
 # 6. A block-gzipped .mgf reads back the same as the plain one.

--- a/2.0/Tests/TEST_MGF/run_tests.sh
+++ b/2.0/Tests/TEST_MGF/run_tests.sh
@@ -11,6 +11,18 @@ EXTRA2=$3
 
 # 1. Hardcalls.  A round trip through the text format has to reproduce the
 #    .mgf and .pos.txt byte for byte, and the .pvar apart from its header.
+fails_with() {
+    local expected=$1
+    shift
+    if "$@" > /dev/null 2> tmp_err.txt; then
+        echo "expected failure: $*"
+        exit 1
+    fi
+    # Error messages are word-wrapped, so the newlines have to come out before
+    # a phrase can be matched across them.
+    tr '\n' ' ' < tmp_err.txt | tr -s ' ' | grep -q "$expected"
+}
+
 plink --simulate simulate.txt --simulate-missing 0.03 --simulate-ncases 60 --simulate-ncontrols 60 --out tmp_hard > /dev/null
 $BUILD/plink2 $EXTRA1 $EXTRA2 --bfile tmp_hard --export mgf --out tmp_hard_e
 $BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_hard_e.mgf tmp_hard_e.pos.txt --out tmp_hard_r
@@ -63,24 +75,35 @@ diff -q <(cut -f 2- tmp_ph_r.psam | tail -n +2) tmp_ph_e.pheno.txt
 # Without 'pheno=' there are no phenotype columns at all.
 head -n 1 tmp_dose_r.psam | grep -q '^#IID$'
 
-# 5. A block-gzipped .mgf reads back the same as the plain one.
+# 5. --psam/--fam supplies real sample IDs in place of the synthesized ones,
+#    without touching the genotypes.
+awk 'BEGIN {print "#IID\tSEX\tPHENO1"; for (i = 0; i < 120; ++i) {print "s" i "\t" (i % 2 + 1) "\t" (i % 2 + 1)}}' > tmp_real.psam
+$BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_dose_e.mgf tmp_dose_e.pos.txt --psam tmp_real.psam --out tmp_ids
+diff -q <(cut -f 1 tmp_ids.psam | tail -n +2) <(seq 0 119 | sed 's/^/s/')
+$BUILD/plink2 $EXTRA1 $EXTRA2 --pfile tmp_ids --export mgf --out tmp_ids_e
+diff -q tmp_dose_e.mgf tmp_ids_e.mgf
+
+# The PLINK 1.x .fam spelling works too, and brings FID along.
+awk 'BEGIN {for (i = 0; i < 120; ++i) {print "f" i, "s" i, 0, 0, (i % 2 + 1), (i % 2 + 1)}}' > tmp_real.fam
+$BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_dose_e.mgf tmp_dose_e.pos.txt --fam tmp_real.fam --out tmp_ids2
+head -n 1 tmp_ids2.psam | grep -q '^#FID	IID'
+diff -q <(cut -f 2 tmp_ids2.psam | tail -n +2) <(seq 0 119 | sed 's/^/s/')
+
+# A row count that disagrees with the .mgf is an error, and so is combining
+# the two phenotype sources.
+head -n 6 tmp_real.psam > tmp_short.psam
+fails_with "tmp_short.psam has 5 samples, while tmp_dose_e.mgf implies 120" \
+    $BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_dose_e.mgf tmp_dose_e.pos.txt --psam tmp_short.psam --out tmp_bad7
+fails_with "cannot be used with --psam/--fam" \
+    $BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_ph_e.mgf tmp_ph_e.pos.txt pheno=tmp_ph_e.pheno.txt --psam tmp_real.psam --out tmp_bad8
+
+# 6. A block-gzipped .mgf reads back the same as the plain one.
 $BUILD/plink2 $EXTRA1 $EXTRA2 --pfile tmp_dose --export mgf bgz --out tmp_bgz
 $BUILD/plink2 $EXTRA1 $EXTRA2 --mgf tmp_bgz.mgf.gz tmp_bgz.pos.txt --out tmp_bgz_r
 $BUILD/plink2 $EXTRA1 $EXTRA2 --pfile tmp_bgz_r --export mgf --out tmp_bgz_e
 diff -q tmp_dose_e.mgf tmp_bgz_e.mgf
 
-# 6. Malformed input has to be rejected, naming the offending line.
-fails_with() {
-    local expected=$1
-    shift
-    if "$@" > /dev/null 2> tmp_err.txt; then
-        echo "expected failure: $*"
-        exit 1
-    fi
-    # Error messages are word-wrapped, so the newlines have to come out before
-    # a phrase can be matched across them.
-    tr '\n' ' ' < tmp_err.txt | tr -s ' ' | grep -q "$expected"
-}
+# 7. Malformed input has to be rejected, naming the offending line.
 
 # A variant with no position.
 head -n 3 tmp_hard_e.pos.txt > tmp_short.pos.txt

--- a/2.0/Tests/TEST_MGF/simulate.txt
+++ b/2.0/Tests/TEST_MGF/simulate.txt
@@ -1,0 +1,3 @@
+80 low_maf_snps 0.05 0.1 0.5 0.25
+80 med_maf_snps 0.1 0.3 0.5 0.25
+80 high_maf_snps 0.3 0.5 0.5 0.25

--- a/2.0/Tests/run_tests.sh
+++ b/2.0/Tests/run_tests.sh
@@ -83,4 +83,9 @@ cd TEST_HET_IBC
 cd ..
 echo "TEST_HET_IBC passed."
 
+cd TEST_MGF
+./run_tests.sh $d $2 $3 > TEST_MGF.log
+cd ..
+echo "TEST_MGF passed."
+
 echo "All tests passed."

--- a/2.0/plink2.cc
+++ b/2.0/plink2.cc
@@ -9583,7 +9583,9 @@ int main(int argc, char** argv) {
           pc.filter_flags |= kfFilterPvarReq;
           pc.dependency_flags |= kfFilterAllReq | kfFilterNoSplitChr;
         } else if (strequal_k_unsafe(flagname_p2, "gf")) {
-          if (unlikely(load_params || xload)) {
+          // --psam/--fam may accompany this, to supply real sample IDs in
+          // place of the synthesized ones.
+          if (unlikely((load_params & (~kfLoadParamsPsam)) || xload)) {
             goto main_ret_INVALID_CMDLINE_INPUT_CONFLICT;
           }
           if (unlikely(EnforceParamCtRange(argvk[arg_idx], param_ct, 2, 3))) {
@@ -10589,7 +10591,7 @@ int main(int argc, char** argv) {
           }
           memcpy(pgenname, fname, slen + 1);
         } else if (strequal_k_unsafe(flagname_p2, "sam")) {
-          if (unlikely(xload & (~(kfXloadVcf | kfXloadBcf | kfXloadPlink1Dosage | kfXloadMap)))) {
+          if (unlikely(xload & (~(kfXloadVcf | kfXloadBcf | kfXloadPlink1Dosage | kfXloadMap | kfXloadMgf)))) {
             goto main_ret_INVALID_CMDLINE_INPUT_CONFLICT;
           }
           if (unlikely(EnforceParamCtRange(argvk[arg_idx], param_ct, 1, 1))) {
@@ -13523,6 +13525,10 @@ int main(int argc, char** argv) {
       logerrputs("Error: --chr-override requires an explicit chromosome set.\n");
       goto main_ret_INVALID_CMDLINE_A;
     }
+    if (unlikely(mgf_pheno_fname && (load_params & kfLoadParamsPsam))) {
+      logerrputs("Error: --mgf 'pheno=' cannot be used with --psam/--fam, since both supply\nphenotypes.\n");
+      goto main_ret_INVALID_CMDLINE_A;
+    }
     if (unlikely((xload & kfXloadPlink1Dosage) && (!(load_params & kfLoadParamsPsam)))) {
       logerrputs("Error: --import-dosage requires a .fam file.\n");
       goto main_ret_INVALID_CMDLINE_A;
@@ -13827,7 +13833,7 @@ int main(int argc, char** argv) {
           } else if (xload & kfXloadEigGeno) {
             reterr = EigfileToPgen(pgenname, psamname, pvarname, const_fid, pc.missing_catname, missing_varid, pc.misc_flags, import_flags, load_filter_log_import_flags, psam_01, id_delim, import_overlong_varids_mode, pc.max_thread_ct, outname, convname_end, &chr_info);
           } else if (xload & kfXloadMgf) {
-            reterr = MgfToPgen(pgenname, pvarname, mgf_pheno_fname, pc.misc_flags, import_flags, load_filter_log_import_flags, pc.hard_call_thresh, pc.dosage_erase_thresh, pc.max_thread_ct, outname, convname_end, &chr_info);
+            reterr = MgfToPgen(pgenname, pvarname, mgf_pheno_fname, (load_params & kfLoadParamsPsam)? psamname : nullptr, pc.missing_catname, pc.misc_flags, import_flags, load_filter_log_import_flags, pc.fam_cols, pc.missing_pheno, psam_01, pc.hard_call_thresh, pc.dosage_erase_thresh, pc.max_thread_ct, outname, convname_end, &chr_info);
           } else if (xload & kfXloadPlink1Dosage) {
             reterr = Plink1DosageToPgen(pgenname, psamname, (xload & kfXloadMap)? pvarname : nullptr, import_single_chr_str, &plink1_dosage_info, pc.missing_catname, pc.misc_flags, import_flags, load_filter_log_import_flags, psam_01, pc.fam_cols, pc.missing_pheno, pc.hard_call_thresh, pc.dosage_erase_thresh, import_dosage_certainty, pc.max_thread_ct, outname, convname_end, &chr_info);
           } else if (xload & kfXload23file) {

--- a/2.0/plink2.cc
+++ b/2.0/plink2.cc
@@ -13525,10 +13525,6 @@ int main(int argc, char** argv) {
       logerrputs("Error: --chr-override requires an explicit chromosome set.\n");
       goto main_ret_INVALID_CMDLINE_A;
     }
-    if (unlikely(mgf_pheno_fname && (load_params & kfLoadParamsPsam))) {
-      logerrputs("Error: --mgf 'pheno=' cannot be used with --psam/--fam, since both supply\nphenotypes.\n");
-      goto main_ret_INVALID_CMDLINE_A;
-    }
     if (unlikely((xload & kfXloadPlink1Dosage) && (!(load_params & kfLoadParamsPsam)))) {
       logerrputs("Error: --import-dosage requires a .fam file.\n");
       goto main_ret_INVALID_CMDLINE_A;

--- a/2.0/plink2.cc
+++ b/2.0/plink2.cc
@@ -160,7 +160,8 @@ FLAGSET_DEF_START()
   kfXloadEigGeno = (1 << 12),
   kfXloadEigInd = (1 << 13),
   kfXloadEigSnp = (1 << 14),
-  kfXload23file = (1 << 15)
+  kfXload23file = (1 << 15),
+  kfXloadMgf = (1 << 16)
 FLAGSET_DEF_END(Xload);
 
 
@@ -3744,6 +3745,7 @@ int main(int argc, char** argv) {
   char* king_cutoff_fprefix = nullptr;
   char* const_fid = nullptr;
   char* import_single_chr_str = nullptr;
+  char* mgf_pheno_fname = nullptr;
   char* ox_missing_code = nullptr;
   char* vcf_dosage_import_field = nullptr;
   uint32_t* rseeds = nullptr;
@@ -9580,6 +9582,34 @@ int main(int argc, char** argv) {
           }
           pc.filter_flags |= kfFilterPvarReq;
           pc.dependency_flags |= kfFilterAllReq | kfFilterNoSplitChr;
+        } else if (strequal_k_unsafe(flagname_p2, "gf")) {
+          if (unlikely(load_params || xload)) {
+            goto main_ret_INVALID_CMDLINE_INPUT_CONFLICT;
+          }
+          if (unlikely(EnforceParamCtRange(argvk[arg_idx], param_ct, 2, 3))) {
+            goto main_ret_INVALID_CMDLINE_2A;
+          }
+          for (uint32_t param_idx = 1; param_idx <= 2; ++param_idx) {
+            const char* cur_fname = argvk[arg_idx + param_idx];
+            const uint32_t slen = strlen(cur_fname);
+            if (unlikely(slen > kPglFnamesize - 1)) {
+              logerrputs("Error: --mgf filename too long.\n");
+              goto main_ret_OPEN_FAIL;
+            }
+            memcpy((param_idx == 1)? pgenname : pvarname, cur_fname, slen + 1);
+          }
+          if (param_ct == 3) {
+            const char* cur_modif = argvk[arg_idx + 3];
+            if (unlikely(!StrStartsWith(cur_modif, "pheno=", strlen(cur_modif)))) {
+              snprintf(g_logbuf, kLogbufSize, "Error: Invalid --mgf argument '%s'.\n", cur_modif);
+              goto main_ret_INVALID_CMDLINE_WWA;
+            }
+            reterr = AllocFname(&(cur_modif[strlen("pheno=")]), "mgf pheno=", &mgf_pheno_fname);
+            if (unlikely(reterr)) {
+              goto main_ret_1;
+            }
+          }
+          xload = kfXloadMgf;
         } else if (strequal_k_unsafe(flagname_p2, "issing-code")) {
           if (unlikely(!(xload & (kfXloadOxGen | kfXloadOxBgen | kfXloadOxHaps)))) {
             // could technically support pure .sample -> .fam/.psam, but let's
@@ -13369,7 +13399,7 @@ int main(int argc, char** argv) {
     }
 
     pc.dependency_flags |= pc.filter_flags;
-    const uint32_t skip_main = (!pc.command_flags1) && (!(xload & (kfXloadVcf | kfXloadBcf | kfXloadOxBgen | kfXloadOxHaps | kfXloadOxSample | kfXloadEigGeno | kfXloadPlink1Dosage | kfXloadGenDummy | kfXloadPed | kfXloadTped)));
+    const uint32_t skip_main = (!pc.command_flags1) && (!(xload & (kfXloadVcf | kfXloadBcf | kfXloadOxBgen | kfXloadOxHaps | kfXloadOxSample | kfXloadEigGeno | kfXloadPlink1Dosage | kfXloadGenDummy | kfXloadPed | kfXloadTped | kfXloadMgf)));
     const uint32_t batch_job = (adjust_file_info.fname != nullptr) || (pc.gwas_ssf_info.fname != nullptr) || (pc.gwas_ssf_info.list_fname != nullptr);
     if (skip_main && (!batch_job)) {
       // add command_flags2 when needed
@@ -13796,6 +13826,8 @@ int main(int argc, char** argv) {
             reterr = OxHapslegendToPgen(pgenname, pvarname, psamname, const_fid, import_single_chr_str, ox_missing_code, pc.missing_catname, missing_varid, pc.misc_flags, import_flags, load_filter_log_import_flags, oxford_import_flags, psam_01, is_update_or_impute_sex, !!pc.splitpar_bound2, pc.sort_vars_mode > kSortNone, id_delim, import_overlong_varids_mode, pc.max_thread_ct, outname, convname_end, &chr_info, &pgi_generated);
           } else if (xload & kfXloadEigGeno) {
             reterr = EigfileToPgen(pgenname, psamname, pvarname, const_fid, pc.missing_catname, missing_varid, pc.misc_flags, import_flags, load_filter_log_import_flags, psam_01, id_delim, import_overlong_varids_mode, pc.max_thread_ct, outname, convname_end, &chr_info);
+          } else if (xload & kfXloadMgf) {
+            reterr = MgfToPgen(pgenname, pvarname, mgf_pheno_fname, pc.misc_flags, import_flags, load_filter_log_import_flags, pc.hard_call_thresh, pc.dosage_erase_thresh, pc.max_thread_ct, outname, convname_end, &chr_info);
           } else if (xload & kfXloadPlink1Dosage) {
             reterr = Plink1DosageToPgen(pgenname, psamname, (xload & kfXloadMap)? pvarname : nullptr, import_single_chr_str, &plink1_dosage_info, pc.missing_catname, pc.misc_flags, import_flags, load_filter_log_import_flags, psam_01, pc.fam_cols, pc.missing_pheno, pc.hard_call_thresh, pc.dosage_erase_thresh, import_dosage_certainty, pc.max_thread_ct, outname, convname_end, &chr_info);
           } else if (xload & kfXload23file) {

--- a/2.0/plink2_help.cc
+++ b/2.0/plink2_help.cc
@@ -243,7 +243,9 @@ PglErr DispHelp(const char* const* argvk, uint32_t param_ct) {
 "    * --psam/--fam supplies real sample IDs (and sex, and phenotypes)\n"
 "      instead.  Since the .mgf has no IDs of its own to match against, the\n"
 "      file just has to have one row per sample, in the .mgf\'s column order.\n"
-"      It cannot be combined with \'pheno=\'.\n"
+"      It can be combined with \'pheno=\' as long as it does not carry\n"
+"      phenotype data itself; a .psam need not have a phenotype column, and a\n"
+"      .fam\'s may be entirely missing.\n"
 "    * This is the inverse of \"--export mgf\".\n\n"
                );
     HelpPrint("import-dosage\0dosage\0map\0", &help_ctrl, 1,

--- a/2.0/plink2_help.cc
+++ b/2.0/plink2_help.cc
@@ -240,6 +240,10 @@ PglErr DispHelp(const char* const* argvk, uint32_t param_ct) {
 "    * Neither file carries sample IDs, so \'per0\', \'per1\', ... are generated,\n"
 "      as with --dummy.  \'pheno=\' names a phenotype file with one row per\n"
 "      sample, whose columns become PHENO1, PHENO2, ...\n"
+"    * --psam/--fam supplies real sample IDs (and sex, and phenotypes)\n"
+"      instead.  Since the .mgf has no IDs of its own to match against, the\n"
+"      file just has to have one row per sample, in the .mgf\'s column order.\n"
+"      It cannot be combined with \'pheno=\'.\n"
 "    * This is the inverse of \"--export mgf\".\n\n"
                );
     HelpPrint("import-dosage\0dosage\0map\0", &help_ctrl, 1,

--- a/2.0/plink2_help.cc
+++ b/2.0/plink2_help.cc
@@ -229,6 +229,19 @@ PglErr DispHelp(const char* const* argvk, uint32_t param_ct) {
 "    * As in PLINK 1.9, 'D'/'I' indel calls are given the complementary allele\n"
 "      code, so that a homozygous call still has two distinct codes.\n\n"
               );
+    HelpPrint("mgf\0", &help_ctrl, 1,
+"  --mgf <.mgf file> <.pos.txt file> ['pheno='<.pheno.txt file>]\n"
+"    Specify BIMBAM mean genotype format input.  The .mgf file has one row per\n"
+"    variant, naming the variant, its ALT and REF alleles, and then one ALT\n"
+"    dosage per sample; the .pos.txt file gives each variant's ID, base-pair\n"
+"    coordinate and chromosome.  Commas are accepted in place of whitespace in\n"
+"    both, and \'NA\', \'-9\', \'?\', \'??\' and \'.\' all mark a missing call; any\n"
+"    other dosage outside [0, 2] is an error.\n"
+"    * Neither file carries sample IDs, so \'per0\', \'per1\', ... are generated,\n"
+"      as with --dummy.  \'pheno=\' names a phenotype file with one row per\n"
+"      sample, whose columns become PHENO1, PHENO2, ...\n"
+"    * This is the inverse of \"--export mgf\".\n\n"
+               );
     HelpPrint("import-dosage\0dosage\0map\0", &help_ctrl, 1,
 "  --import-dosage <allele dosage file> ['noheader'] ['id-delim='<char>]\n"
 "                  ['skip0='<i>] ['skip1='<j>] ['skip2='<k>] ['dose1']\n"

--- a/2.0/plink2_import_legacy.cc
+++ b/2.0/plink2_import_legacy.cc
@@ -673,7 +673,11 @@ PglErr LoadMap(const char* mapname, MiscFlags misc_flags, LoadFilterLogFlags loa
 }
 
 // Ok for in_psamname to alias outname.
-PglErr RewritePsam(const char* in_psamname, const char* missing_catname, MiscFlags misc_flags, FamCol fam_cols, int32_t missing_pheno, uint32_t psam_01, uint32_t max_thread_ct, char* outname, char* outname_end, uint32_t* raw_sample_ctp) {
+// pheno_info_presentp, when provided, reports whether the input actually
+// carried a phenotype value for anybody.  A .psam need not have a phenotype
+// column at all, and a .fam's may be entirely -9, so "has a column" is not
+// the same question.
+PglErr RewritePsam(const char* in_psamname, const char* missing_catname, MiscFlags misc_flags, FamCol fam_cols, int32_t missing_pheno, uint32_t psam_01, uint32_t max_thread_ct, char* outname, char* outname_end, uint32_t* raw_sample_ctp, uint32_t* pheno_info_presentp) {
   unsigned char* bigstack_mark = g_bigstack_base;
   PhenoCol* pheno_cols = nullptr;
   char* pheno_names = nullptr;
@@ -694,6 +698,17 @@ PglErr RewritePsam(const char* in_psamname, const char* missing_catname, MiscFla
     }
     if (raw_sample_ctp) {
       *raw_sample_ctp = raw_sample_ct;
+    }
+    if (pheno_info_presentp) {
+      uint32_t pheno_info_present = 0;
+      const uint32_t raw_sample_ctl = BitCtToWordCt(raw_sample_ct);
+      for (uint32_t pheno_idx = 0; pheno_idx != pheno_ct; ++pheno_idx) {
+        if (!AllWordsAreZero(pheno_cols[pheno_idx].nonmiss, raw_sample_ctl)) {
+          pheno_info_present = 1;
+          break;
+        }
+      }
+      *pheno_info_presentp = pheno_info_present;
     }
 
     snprintf(outname_end, kMaxOutfnameExtBlen, ".psam");
@@ -770,7 +785,7 @@ PglErr TpedToPgen(const char* tpedname, const char* tfamname, const char* missin
       // Only need to generate a .psam if this is a conversion-only run, or
       // --keep-autoconv was specified.  Otherwise Plink2Core() can simply
       // interpret the .tfam as a psam file.
-      reterr = RewritePsam(tfamname, missing_catname, misc_flags, fam_cols, missing_pheno, 0, max_thread_ct, outname, outname_end, &tfam_sample_ct);
+      reterr = RewritePsam(tfamname, missing_catname, misc_flags, fam_cols, missing_pheno, 0, max_thread_ct, outname, outname_end, &tfam_sample_ct, nullptr);
       if (unlikely(reterr)) {
         goto TpedToPgen_ret_1;
       }
@@ -2300,7 +2315,7 @@ PglErr PedmapToPgen(const char* pedname, const char* mapname, const char* missin
     *outname_end = '.';
     BigstackEndSet(tmp_alloc_end);
 
-    reterr = RewritePsam(outname, missing_catname, misc_flags, fam_cols, missing_pheno, psam_01, max_thread_ct, outname, outname_end, nullptr);
+    reterr = RewritePsam(outname, missing_catname, misc_flags, fam_cols, missing_pheno, psam_01, max_thread_ct, outname, outname_end, nullptr, nullptr);
     if (unlikely(reterr)) {
       goto PedmapToPgen_ret_1;
     }
@@ -2461,6 +2476,103 @@ HEADER_INLINE void MgfCommasToSpaces(char* line_start) {
   }
 }
 
+// Appends 'pheno=' columns to an already-written .psam.  RewritePsam() has
+// just produced a well-formed file with one line per sample in the .mgf's
+// order, so this is a column append rather than a merge.
+PglErr AppendPhenoColsToPsam(const char* pheno_lines, uint32_t sample_ct, uint32_t pheno_col_ct, uintptr_t max_pheno_line_blen, const char* psamname) {
+  unsigned char* bigstack_mark = g_bigstack_base;
+  FILE* outfile = nullptr;
+  TextStream txs;
+  PreinitTextStream(&txs);
+  PglErr reterr = kPglRetSuccess;
+  {
+    // The file has one line per sample plus a header, so it fits in memory
+    // comfortably.
+    char** psam_lines;
+    if (unlikely(BIGSTACK_ALLOC_X(char*, sample_ct + 1, &psam_lines))) {
+      goto AppendPhenoColsToPsam_ret_NOMEM;
+    }
+    reterr = SizeAndInitTextStream(psamname, bigstack_left() / 4, 1, &txs);
+    if (unlikely(reterr)) {
+      goto AppendPhenoColsToPsam_ret_TSTREAM_FAIL;
+    }
+    for (uint32_t line_idx = 0; line_idx != sample_ct + 1; ++line_idx) {
+      char* line_start = TextGet(&txs);
+      if (unlikely(!line_start)) {
+        logerrprintfww("Error: %s ended early.\n", psamname);
+        goto AppendPhenoColsToPsam_ret_REWIND_FAIL;
+      }
+      char* line_end = AdvToDelim(line_start, '\n');
+      const uintptr_t line_slen = line_end - line_start;
+      char* stored;
+      if (unlikely(bigstack_alloc_c(line_slen + 1, &stored))) {
+        goto AppendPhenoColsToPsam_ret_NOMEM;
+      }
+      memcpyx(stored, line_start, line_slen, '\0');
+      psam_lines[line_idx] = stored;
+    }
+    if (unlikely(CleanupTextStream2(psamname, &txs, &reterr))) {
+      goto AppendPhenoColsToPsam_ret_1;
+    }
+
+    if (unlikely(fopen_checked(psamname, FOPEN_WB, &outfile))) {
+      goto AppendPhenoColsToPsam_ret_OPEN_FAIL;
+    }
+    const uintptr_t writebuf_blen = kMaxMediumLine + kMaxIdSlen + max_pheno_line_blen + 64;
+    char* writebuf;
+    if (unlikely(bigstack_alloc_c(writebuf_blen, &writebuf))) {
+      goto AppendPhenoColsToPsam_ret_NOMEM;
+    }
+    char* writebuf_flush = &(writebuf[kMaxMediumLine]);
+    char* write_iter = strcpya(writebuf, psam_lines[0]);
+    for (uint32_t pheno_idx = 0; pheno_idx != pheno_col_ct; ++pheno_idx) {
+      write_iter = strcpya_k(write_iter, "\tPHENO");
+      write_iter = u32toa(pheno_idx + 1, write_iter);
+    }
+    AppendBinaryEoln(&write_iter);
+    for (uint32_t sample_idx = 0; sample_idx != sample_ct; ++sample_idx) {
+      write_iter = strcpya(write_iter, psam_lines[sample_idx + 1]);
+      const char* pheno_iter = &(pheno_lines[sample_idx * max_pheno_line_blen]);
+      for (uint32_t pheno_idx = 0; pheno_idx != pheno_col_ct; ++pheno_idx) {
+        pheno_iter = FirstNonTspace(pheno_iter);
+        const char* token_end = CurTokenEnd(pheno_iter);
+        *write_iter++ = '\t';
+        write_iter = memcpya(write_iter, pheno_iter, token_end - pheno_iter);
+        pheno_iter = token_end;
+      }
+      AppendBinaryEoln(&write_iter);
+      if (unlikely(fwrite_ck(writebuf_flush, outfile, &write_iter))) {
+        goto AppendPhenoColsToPsam_ret_WRITE_FAIL;
+      }
+    }
+    if (unlikely(fclose_flush_null(writebuf_flush, write_iter, &outfile))) {
+      goto AppendPhenoColsToPsam_ret_WRITE_FAIL;
+    }
+  }
+  while (0) {
+  AppendPhenoColsToPsam_ret_NOMEM:
+    reterr = kPglRetNomem;
+    break;
+  AppendPhenoColsToPsam_ret_OPEN_FAIL:
+    reterr = kPglRetOpenFail;
+    break;
+  AppendPhenoColsToPsam_ret_WRITE_FAIL:
+    reterr = kPglRetWriteFail;
+    break;
+  AppendPhenoColsToPsam_ret_REWIND_FAIL:
+    reterr = kPglRetRewindFail;
+    break;
+  AppendPhenoColsToPsam_ret_TSTREAM_FAIL:
+    TextStreamErrPrint(psamname, &txs);
+    break;
+  }
+ AppendPhenoColsToPsam_ret_1:
+  CleanupTextStream2(psamname, &txs, &reterr);
+  fclose_cond(outfile);
+  BigstackReset(bigstack_mark);
+  return reterr;
+}
+
 PglErr MgfToPgen(const char* mgfname, const char* posname, const char* phenoname, const char* preexisting_psamname, const char* missing_catname, MiscFlags misc_flags, ImportFlags import_flags, LoadFilterLogFlags load_filter_log_import_flags, FamCol fam_cols, int32_t missing_pheno, uint32_t psam_01, uint32_t hard_call_thresh, uint32_t dosage_erase_thresh, uint32_t max_thread_ct, char* outname, char* outname_end, ChrInfo* cip) {
   unsigned char* bigstack_mark = g_bigstack_base;
   unsigned char* bigstack_end_mark = g_bigstack_end;
@@ -2615,23 +2727,11 @@ PglErr MgfToPgen(const char* mgfname, const char* posname, const char* phenoname
       goto MgfToPgen_ret_1;
     }
 
-    // 3. Write the .psam.  With --psam/--fam the sample IDs (and phenotypes,
-    //    and sex) come from that file, which only has to have the right
-    //    number of rows since the .mgf carries no IDs of its own to match
-    //    against.  Otherwise they are synthesized, and 'pheno=' supplies the
-    //    phenotypes.
-    if (preexisting_psamname) {
-      uint32_t psam_sample_ct = 0;
-      reterr = RewritePsam(preexisting_psamname, missing_catname, misc_flags, fam_cols, missing_pheno, psam_01, max_thread_ct, outname, outname_end, &psam_sample_ct);
-      if (unlikely(reterr)) {
-        goto MgfToPgen_ret_1;
-      }
-      if (unlikely(psam_sample_ct != sample_ct)) {
-        snprintf(g_logbuf, kLogbufSize, "Error: %s has %u sample%s, while %s implies %u.\n", preexisting_psamname, psam_sample_ct, (psam_sample_ct == 1)? "" : "s", mgfname, sample_ct);
-        goto MgfToPgen_ret_INCONSISTENT_INPUT_WW;
-      }
-      logprintfww("--mgf: %u sample%s and %u variant%s present (sample IDs from %s).\n", sample_ct, (sample_ct == 1)? "" : "s", variant_ct, (variant_ct == 1)? "" : "s", preexisting_psamname);
-    } else {
+    // 3. Write the .psam.  --psam/--fam supplies the sample IDs (and sex, and
+    //    any phenotypes it carries); otherwise they are synthesized.  Either
+    //    way 'pheno=' can supply phenotypes, as long as the .psam/.fam does
+    //    not also carry some.
+    do {
       uint32_t pheno_col_ct = 0;
       char* pheno_lines = nullptr;
       uintptr_t max_pheno_line_blen = 0;
@@ -2688,6 +2788,33 @@ PglErr MgfToPgen(const char* mgfname, const char* posname, const char* phenoname
           goto MgfToPgen_ret_1;
         }
       }
+      if (preexisting_psamname) {
+        uint32_t psam_sample_ct = 0;
+        uint32_t psam_pheno_info_present = 0;
+        reterr = RewritePsam(preexisting_psamname, missing_catname, misc_flags, fam_cols, missing_pheno, psam_01, max_thread_ct, outname, outname_end, &psam_sample_ct, &psam_pheno_info_present);
+        if (unlikely(reterr)) {
+          goto MgfToPgen_ret_1;
+        }
+        if (unlikely(psam_sample_ct != sample_ct)) {
+          snprintf(g_logbuf, kLogbufSize, "Error: %s has %u sample%s, while %s implies %u.\n", preexisting_psamname, psam_sample_ct, (psam_sample_ct == 1)? "" : "s", mgfname, sample_ct);
+          goto MgfToPgen_ret_INCONSISTENT_INPUT_WW;
+        }
+        if (pheno_col_ct) {
+          // A .psam need not have a phenotype column, and a .fam's may be
+          // entirely missing, so 'pheno=' is only a conflict when the file
+          // actually carries a value for somebody.
+          if (unlikely(psam_pheno_info_present)) {
+            snprintf(g_logbuf, kLogbufSize, "Error: %s contains phenotype data, so it cannot be combined with --mgf 'pheno='.\n", preexisting_psamname);
+            goto MgfToPgen_ret_INCONSISTENT_INPUT_WW;
+          }
+          reterr = AppendPhenoColsToPsam(pheno_lines, sample_ct, pheno_col_ct, max_pheno_line_blen, outname);
+          if (unlikely(reterr)) {
+            goto MgfToPgen_ret_1;
+          }
+        }
+        logprintfww("--mgf: %u sample%s and %u variant%s present (sample IDs from %s%s).\n", sample_ct, (sample_ct == 1)? "" : "s", variant_ct, (variant_ct == 1)? "" : "s", preexisting_psamname, pheno_col_ct? ", phenotypes from pheno=" : "");
+        break;
+      }
       snprintf(outname_end, kMaxOutfnameExtBlen, ".psam");
       if (unlikely(fopen_checked(outname, FOPEN_WB, &psamfile))) {
         goto MgfToPgen_ret_OPEN_FAIL;
@@ -2726,7 +2853,7 @@ PglErr MgfToPgen(const char* mgfname, const char* posname, const char* phenoname
         goto MgfToPgen_ret_WRITE_FAIL;
       }
       logprintfww("--mgf: %u sample%s and %u variant%s present%s.\n", sample_ct, (sample_ct == 1)? "" : "s", variant_ct, (variant_ct == 1)? "" : "s", pheno_col_ct? " (with phenotype data)" : "");
-    }
+    } while (0);
 
     // 4. Second pass: write the .pvar and .pgen.
     cur_fname = mgfname;

--- a/2.0/plink2_import_legacy.cc
+++ b/2.0/plink2_import_legacy.cc
@@ -35,6 +35,8 @@
 #include "plink2_data.h"
 #include "plink2_decompress.h"
 #include "plink2_import_legacy.h"
+
+#include "include/plink2_htable.h"
 #include "plink2_psam.h"
 
 // This covers formats that are fully supported by PLINK 1.x (no multiallelic
@@ -2406,6 +2408,529 @@ PglErr PedmapToPgen(const char* pedname, const char* mapname, const char* missin
   CleanupTextStream2(pedname, &ped_txs, &reterr);
   fclose_cond(tmp_fam_file);
   fclose_cond(indmaj_bed_file);
+  BigstackDoubleReset(bigstack_mark, bigstack_end_mark);
+  return reterr;
+}
+
+// BIMBAM mean genotype format import.
+//
+// The .mgf file has one row per variant,
+//   <variant ID> <ALT allele> <REF allele> <ALT dosage>...
+// with commas accepted in place of whitespace and "NA" for a missing call, and
+// the companion .pos.txt names each variant's position,
+//   <variant ID> <bp> <chromosome>
+// Neither file carries sample IDs, so per0..perN-1 are synthesized, matching
+// --dummy and the Oxford importer.
+// The missing-call spellings the .mgf format is read with: BIMBAM's own "NA",
+// PLINK's "-9", and the "?"/"??" some converters emit.
+HEADER_INLINE uint32_t IsMgfMissingToken(const char* token, uint32_t token_slen) {
+  if (token_slen == 1) {
+    return (token[0] == '?') || (token[0] == '.');
+  }
+  if (token_slen != 2) {
+    return 0;
+  }
+  return ((token[0] == '?') && (token[1] == '?')) ||
+         ((token[0] == '-') && (token[1] == '9')) ||
+         (((token[0] & 0xdf) == 'N') && ((token[1] & 0xdf) == 'A'));
+}
+
+// BIMBAM's .mgf and .pos.txt accept commas in place of whitespace, so both are
+// token separators.
+HEADER_INLINE char* MgfTokenEnd(char* str_iter) {
+  while (!IsSpaceOrEoln(*str_iter)) {
+    if (*str_iter == ',') {
+      break;
+    }
+    ++str_iter;
+  }
+  return str_iter;
+}
+
+// Rewrites the line's commas as spaces, so the ordinary token scanners can be
+// used on it afterward.
+HEADER_INLINE void MgfCommasToSpaces(char* line_start) {
+  for (char* line_iter = line_start; ; ++line_iter) {
+    const char cc = *line_iter;
+    if (cc == '\n') {
+      return;
+    }
+    if (cc == ',') {
+      *line_iter = ' ';
+    }
+  }
+}
+
+PglErr MgfToPgen(const char* mgfname, const char* posname, const char* phenoname, MiscFlags misc_flags, ImportFlags import_flags, LoadFilterLogFlags load_filter_log_import_flags, uint32_t hard_call_thresh, uint32_t dosage_erase_thresh, uint32_t max_thread_ct, char* outname, char* outname_end, ChrInfo* cip) {
+  unsigned char* bigstack_mark = g_bigstack_base;
+  unsigned char* bigstack_end_mark = g_bigstack_end;
+  FILE* psamfile = nullptr;
+  uintptr_t line_idx = 0;
+  const char* cur_fname = posname;
+  PglErr reterr = kPglRetSuccess;
+  char* pvar_cswritep = nullptr;
+  CompressStreamState pvar_css;
+  PreinitCstream(&pvar_css);
+  TextStream txs;
+  STPgenWriter spgw;
+  PreinitTextStream(&txs);
+  PreinitSpgw(&spgw);
+  {
+    const uint32_t decompress_thread_ct = (max_thread_ct > 1)? (max_thread_ct - 1) : 1;
+    FinalizeChrset(load_filter_log_import_flags, cip);
+
+    // 1. Read .pos.txt into an ID -> (chromosome, bp) table.
+    uint32_t pos_variant_ct = 0;
+    uintptr_t max_pos_id_blen = 2;
+    reterr = SizeAndInitTextStream(posname, bigstack_left() / 4, decompress_thread_ct, &txs);
+    if (unlikely(reterr)) {
+      goto MgfToPgen_ret_TSTREAM_FAIL;
+    }
+    for (line_idx = 1; ; ++line_idx) {
+      char* line_start = TextGet(&txs);
+      if (!line_start) {
+        break;
+      }
+      // Commas are separators in this format too, so the ID ends at the first
+      // one just as it would at whitespace.
+      const char* id_end = MgfTokenEnd(line_start);
+      const uintptr_t id_blen = 1 + S_CAST(uintptr_t, id_end - line_start);
+      if (id_blen > max_pos_id_blen) {
+        max_pos_id_blen = id_blen;
+      }
+      ++pos_variant_ct;
+    }
+    if (unlikely(TextStreamErrcode2(&txs, &reterr))) {
+      goto MgfToPgen_ret_TSTREAM_FAIL;
+    }
+    if (unlikely(!pos_variant_ct)) {
+      snprintf(g_logbuf, kLogbufSize, "Error: %s is empty.\n", posname);
+      goto MgfToPgen_ret_MALFORMED_INPUT_WW;
+    }
+    char* pos_ids;
+    uint32_t* pos_bps;
+    uint32_t* pos_chr_codes;
+    if (unlikely(bigstack_alloc_c(pos_variant_ct * max_pos_id_blen, &pos_ids) ||
+                 bigstack_alloc_u32(pos_variant_ct, &pos_bps) ||
+                 bigstack_alloc_u32(pos_variant_ct, &pos_chr_codes))) {
+      goto MgfToPgen_ret_NOMEM;
+    }
+    reterr = TextRetarget(posname, &txs);
+    if (unlikely(reterr)) {
+      goto MgfToPgen_ret_TSTREAM_FAIL;
+    }
+    const uint32_t prohibit_extra_chr = (misc_flags / kfMiscProhibitExtraChr) & 1;
+    line_idx = 0;
+    for (uint32_t pos_idx = 0; pos_idx != pos_variant_ct; ++pos_idx) {
+      ++line_idx;
+      char* line_start = TextGet(&txs);
+      if (unlikely(!line_start)) {
+        goto MgfToPgen_ret_REWIND_FAIL;
+      }
+      MgfCommasToSpaces(line_start);
+      char* id_end = CurTokenEnd(line_start);
+      memcpyx(&(pos_ids[pos_idx * max_pos_id_blen]), line_start, id_end - line_start, '\0');
+      char* bp_start = FirstNonTspace(id_end);
+      char* chr_start = NextToken(bp_start);
+      if (unlikely(!chr_start)) {
+        goto MgfToPgen_ret_MISSING_TOKENS;
+      }
+      int32_t cur_bp;
+      if (unlikely(ScanIntAbsDefcap(bp_start, &cur_bp) || (cur_bp < 0))) {
+        snprintf(g_logbuf, kLogbufSize, "Error: Invalid bp coordinate on line %" PRIuPTR " of %s.\n", line_idx, posname);
+        goto MgfToPgen_ret_MALFORMED_INPUT_WW;
+      }
+      pos_bps[pos_idx] = cur_bp;
+      char* chr_end = CurTokenEnd(chr_start);
+      *chr_end = '\0';
+      uint32_t cur_chr_code;
+      reterr = GetOrAddChrCodeDestructive(posname, line_idx, prohibit_extra_chr, chr_start, chr_end, cip, &cur_chr_code);
+      if (unlikely(reterr)) {
+        goto MgfToPgen_ret_1;
+      }
+      pos_chr_codes[pos_idx] = cur_chr_code;
+    }
+    if (unlikely(CleanupTextStream2(posname, &txs, &reterr))) {
+      goto MgfToPgen_ret_1;
+    }
+    const uint32_t pos_htable_size = GetHtableFastSize(pos_variant_ct);
+    uint32_t* pos_htable;
+    if (unlikely(bigstack_end_alloc_u32(pos_htable_size, &pos_htable))) {
+      goto MgfToPgen_ret_NOMEM;
+    }
+    const uint32_t duplicate_idx = PopulateStrboxHtable(pos_ids, pos_variant_ct, max_pos_id_blen, pos_htable_size, pos_htable);
+    if (unlikely(duplicate_idx)) {
+      snprintf(g_logbuf, kLogbufSize, "Error: Duplicate variant ID '%s' in %s.\n", &(pos_ids[duplicate_idx * max_pos_id_blen]), posname);
+      goto MgfToPgen_ret_MALFORMED_INPUT_WW;
+    }
+    logprintf("--mgf: %u variant position%s loaded from %s.\n", pos_variant_ct, (pos_variant_ct == 1)? "" : "s", posname);
+
+    // 2. First pass over the .mgf: sample and variant counts.
+    cur_fname = mgfname;
+    reterr = SizeAndInitTextStream(mgfname, bigstack_left() / 4, decompress_thread_ct, &txs);
+    if (unlikely(reterr)) {
+      goto MgfToPgen_ret_TSTREAM_FAIL;
+    }
+    uint32_t sample_ct = 0;
+    uint32_t variant_ct = 0;
+    uintptr_t max_line_blen = 0;
+    for (line_idx = 1; ; ++line_idx) {
+      char* line_start = TextGet(&txs);
+      if (!line_start) {
+        break;
+      }
+      char* line_end = AdvToDelim(line_start, '\n');
+      const uintptr_t line_blen = 1 + S_CAST(uintptr_t, line_end - line_start);
+      if (line_blen > max_line_blen) {
+        max_line_blen = line_blen;
+      }
+      // Commas are separators here, so they must not survive into the token
+      // scan below.
+      for (char* cc_iter = line_start; cc_iter != line_end; ++cc_iter) {
+        if (*cc_iter == ',') {
+          *cc_iter = ' ';
+        }
+      }
+      const uint32_t token_ct = CountTokens(line_start);
+      if (!sample_ct) {
+        if (unlikely(token_ct < 4)) {
+          snprintf(g_logbuf, kLogbufSize, "Error: Line %" PRIuPTR " of %s has fewer tokens than expected.\n", line_idx, mgfname);
+          goto MgfToPgen_ret_MALFORMED_INPUT_WW;
+        }
+        sample_ct = token_ct - 3;
+      } else if (unlikely(token_ct != sample_ct + 3)) {
+        snprintf(g_logbuf, kLogbufSize, "Error: Line %" PRIuPTR " of %s has %u token%s; %u expected.\n", line_idx, mgfname, token_ct, (token_ct == 1)? "" : "s", sample_ct + 3);
+        goto MgfToPgen_ret_MALFORMED_INPUT_WW;
+      }
+      ++variant_ct;
+    }
+    if (unlikely(TextStreamErrcode2(&txs, &reterr))) {
+      goto MgfToPgen_ret_TSTREAM_FAIL;
+    }
+    if (unlikely(!variant_ct)) {
+      snprintf(g_logbuf, kLogbufSize, "Error: %s is empty.\n", mgfname);
+      goto MgfToPgen_ret_MALFORMED_INPUT_WW;
+    }
+    if (unlikely(CleanupTextStream2(mgfname, &txs, &reterr))) {
+      goto MgfToPgen_ret_1;
+    }
+
+    // 3. Write the .psam, with synthesized IDs and any phenotypes from the
+    //    .pheno.txt file.
+    {
+      uint32_t pheno_col_ct = 0;
+      char* pheno_lines = nullptr;
+      uintptr_t max_pheno_line_blen = 0;
+      if (phenoname) {
+        cur_fname = phenoname;
+        reterr = SizeAndInitTextStream(phenoname, bigstack_left() / 8, 1, &txs);
+        if (unlikely(reterr)) {
+          goto MgfToPgen_ret_TSTREAM_FAIL;
+        }
+        uint32_t pheno_row_ct = 0;
+        for (line_idx = 1; ; ++line_idx) {
+          char* line_start = TextGet(&txs);
+          if (!line_start) {
+            break;
+          }
+          const uintptr_t line_blen = 1 + S_CAST(uintptr_t, AdvToDelim(line_start, '\n') - line_start);
+          if (line_blen > max_pheno_line_blen) {
+            max_pheno_line_blen = line_blen;
+          }
+          const uint32_t token_ct = CountTokens(line_start);
+          if (!pheno_col_ct) {
+            pheno_col_ct = token_ct;
+          } else if (unlikely(token_ct != pheno_col_ct)) {
+            snprintf(g_logbuf, kLogbufSize, "Error: Line %" PRIuPTR " of %s has %u token%s; %u expected.\n", line_idx, phenoname, token_ct, (token_ct == 1)? "" : "s", pheno_col_ct);
+            goto MgfToPgen_ret_MALFORMED_INPUT_WW;
+          }
+          ++pheno_row_ct;
+        }
+        if (unlikely(TextStreamErrcode2(&txs, &reterr))) {
+          goto MgfToPgen_ret_TSTREAM_FAIL;
+        }
+        if (unlikely(pheno_row_ct != sample_ct)) {
+          snprintf(g_logbuf, kLogbufSize, "Error: %s has %u row%s, while %s implies %u sample%s.\n", phenoname, pheno_row_ct, (pheno_row_ct == 1)? "" : "s", mgfname, sample_ct, (sample_ct == 1)? "" : "s");
+          goto MgfToPgen_ret_INCONSISTENT_INPUT_WW;
+        }
+        if (unlikely(bigstack_alloc_c(S_CAST(uintptr_t, sample_ct) * max_pheno_line_blen, &pheno_lines))) {
+          goto MgfToPgen_ret_NOMEM;
+        }
+        reterr = TextRetarget(phenoname, &txs);
+        if (unlikely(reterr)) {
+          goto MgfToPgen_ret_TSTREAM_FAIL;
+        }
+        line_idx = 0;
+        for (uint32_t sample_idx = 0; sample_idx != sample_ct; ++sample_idx) {
+          ++line_idx;
+          char* line_start = TextGet(&txs);
+          if (unlikely(!line_start)) {
+            goto MgfToPgen_ret_REWIND_FAIL;
+          }
+          char* line_end = AdvToDelim(line_start, '\n');
+          memcpyx(&(pheno_lines[sample_idx * max_pheno_line_blen]), line_start, line_end - line_start, '\0');
+        }
+        if (unlikely(CleanupTextStream2(phenoname, &txs, &reterr))) {
+          goto MgfToPgen_ret_1;
+        }
+      }
+      snprintf(outname_end, kMaxOutfnameExtBlen, ".psam");
+      if (unlikely(fopen_checked(outname, FOPEN_WB, &psamfile))) {
+        goto MgfToPgen_ret_OPEN_FAIL;
+      }
+      const uintptr_t writebuf_blen = kMaxMediumLine + MAXV(max_pheno_line_blen, 64);
+      char* writebuf;
+      if (unlikely(bigstack_alloc_c(writebuf_blen, &writebuf))) {
+        goto MgfToPgen_ret_NOMEM;
+      }
+      char* writebuf_flush = &(writebuf[kMaxMediumLine]);
+      char* write_iter = strcpya_k(writebuf, "#IID");
+      for (uint32_t pheno_idx = 0; pheno_idx != pheno_col_ct; ++pheno_idx) {
+        write_iter = strcpya_k(write_iter, "\tPHENO");
+        write_iter = u32toa(pheno_idx + 1, write_iter);
+      }
+      AppendBinaryEoln(&write_iter);
+      for (uint32_t sample_idx = 0; sample_idx != sample_ct; ++sample_idx) {
+        write_iter = strcpya_k(write_iter, "per");
+        write_iter = u32toa(sample_idx, write_iter);
+        if (pheno_col_ct) {
+          const char* pheno_iter = &(pheno_lines[sample_idx * max_pheno_line_blen]);
+          for (uint32_t pheno_idx = 0; pheno_idx != pheno_col_ct; ++pheno_idx) {
+            pheno_iter = FirstNonTspace(pheno_iter);
+            const char* token_end = CurTokenEnd(pheno_iter);
+            *write_iter++ = '\t';
+            write_iter = memcpya(write_iter, pheno_iter, token_end - pheno_iter);
+            pheno_iter = token_end;
+          }
+        }
+        AppendBinaryEoln(&write_iter);
+        if (unlikely(fwrite_ck(writebuf_flush, psamfile, &write_iter))) {
+          goto MgfToPgen_ret_WRITE_FAIL;
+        }
+      }
+      if (unlikely(fclose_flush_null(writebuf_flush, write_iter, &psamfile))) {
+        goto MgfToPgen_ret_WRITE_FAIL;
+      }
+      logprintfww("--mgf: %u sample%s and %u variant%s present%s.\n", sample_ct, (sample_ct == 1)? "" : "s", variant_ct, (variant_ct == 1)? "" : "s", pheno_col_ct? " (with phenotype data)" : "");
+    }
+
+    // 4. Second pass: write the .pvar and .pgen.
+    cur_fname = mgfname;
+    reterr = InitTextStream(mgfname, MAXV(max_line_blen, kTextStreamBlenFast), decompress_thread_ct, &txs);
+    if (unlikely(reterr)) {
+      goto MgfToPgen_ret_TSTREAM_FAIL;
+    }
+    snprintf(outname_end, kMaxOutfnameExtBlen, ".pvar");
+    const uint32_t output_zst = (import_flags / kfImportKeepAutoconvVzs) & 1;
+    if (output_zst) {
+      snprintf(&(outname_end[5]), kMaxOutfnameExtBlen - 5, ".zst");
+    }
+    reterr = InitCstreamAlloc(outname, 0, output_zst, 1, kCompressStreamBlock + 64 + max_line_blen, &pvar_css, &pvar_cswritep);
+    if (unlikely(reterr)) {
+      goto MgfToPgen_ret_1;
+    }
+    pvar_cswritep = strcpya_k(pvar_cswritep, "#CHROM\tPOS\tID\tREF\tALT" EOLN_STR);
+
+    snprintf(outname_end, kMaxOutfnameExtBlen, ".pgen");
+    uintptr_t spgw_alloc_cacheline_ct;
+    uint32_t max_vrec_len;
+    reterr = SpgwInitPhase1(outname, nullptr, nullptr, variant_ct, sample_ct, 0, kPgenWriteBackwardSeek, kfPgenGlobalDosagePresent, 2, &spgw, &spgw_alloc_cacheline_ct, &max_vrec_len);
+    if (unlikely(reterr)) {
+      if (reterr == kPglRetOpenFail) {
+        logerrprintfww(kErrprintfFopen, outname, strerror(errno));
+      }
+      goto MgfToPgen_ret_1;
+    }
+    unsigned char* spgw_alloc;
+    if (unlikely(bigstack_alloc_uc(spgw_alloc_cacheline_ct * kCacheline, &spgw_alloc))) {
+      goto MgfToPgen_ret_NOMEM;
+    }
+    SpgwInitPhase2(max_vrec_len, &spgw, spgw_alloc);
+
+    const uint32_t sample_ctl2 = NypCtToWordCt(sample_ct);
+    const uint32_t sample_ctl = BitCtToWordCt(sample_ct);
+    uintptr_t* genovec;
+    uintptr_t* dosage_present;
+    Dosage* dosage_main;
+    if (unlikely(bigstack_alloc_w(sample_ctl2, &genovec) ||
+                 bigstack_alloc_w(sample_ctl, &dosage_present) ||
+                 bigstack_alloc_dosage(sample_ct, &dosage_main))) {
+      goto MgfToPgen_ret_NOMEM;
+    }
+    const uint32_t hard_call_halfdist = kDosage4th - hard_call_thresh;
+    const uint32_t dosage_erase_halfdist = kDosage4th - dosage_erase_thresh;
+
+    fputs("--mgf: 0%", stdout);
+    fflush(stdout);
+    uint32_t pct = 0;
+    uint32_t next_print_idx = (variant_ct + 99) / 100;
+    line_idx = 0;
+    for (uint32_t variant_idx = 0; variant_idx != variant_ct; ++variant_idx) {
+      ++line_idx;
+      char* line_start = TextGet(&txs);
+      if (unlikely(!line_start)) {
+        goto MgfToPgen_ret_REWIND_FAIL;
+      }
+      char* line_end = AdvToDelim(line_start, '\n');
+      for (char* cc_iter = line_start; cc_iter != line_end; ++cc_iter) {
+        if (*cc_iter == ',') {
+          *cc_iter = ' ';
+        }
+      }
+      char* id_end = CurTokenEnd(line_start);
+      const uint32_t id_slen = id_end - line_start;
+      // The ID token is not null-terminated here, hence the Nnt variant.
+      const uint32_t pos_idx = StrboxHtableFindNnt(line_start, pos_ids, pos_htable, max_pos_id_blen, id_slen, pos_htable_size);
+      if (unlikely(pos_idx == UINT32_MAX)) {
+        *id_end = '\0';
+        snprintf(g_logbuf, kLogbufSize, "Error: Variant '%s' on line %" PRIuPTR " of %s is absent from %s.\n", line_start, line_idx, mgfname, posname);
+        goto MgfToPgen_ret_INCONSISTENT_INPUT_WW;
+      }
+      char* alt_start = FirstNonTspace(id_end);
+      char* alt_end = CurTokenEnd(alt_start);
+      char* ref_start = FirstNonTspace(alt_end);
+      char* ref_end = CurTokenEnd(ref_start);
+      char* dosage_iter = FirstNonTspace(ref_end);
+
+      pvar_cswritep = chrtoa(cip, pos_chr_codes[pos_idx], pvar_cswritep);
+      *pvar_cswritep++ = '\t';
+      pvar_cswritep = u32toa_x(pos_bps[pos_idx], '\t', pvar_cswritep);
+      pvar_cswritep = memcpyax(pvar_cswritep, line_start, id_slen, '\t');
+      pvar_cswritep = memcpyax(pvar_cswritep, ref_start, ref_end - ref_start, '\t');
+      pvar_cswritep = memcpya(pvar_cswritep, alt_start, alt_end - alt_start);
+      AppendBinaryEoln(&pvar_cswritep);
+      if (unlikely(Cswrite(&pvar_css, &pvar_cswritep))) {
+        goto MgfToPgen_ret_WRITE_FAIL;
+      }
+
+      Dosage* dosage_main_iter = dosage_main;
+      uint32_t inner_loop_last = kBitsPerWordD2 - 1;
+      const uint32_t sample_ctl2_m1 = sample_ctl2 - 1;
+      for (uint32_t widx = 0; ; ++widx) {
+        if (widx >= sample_ctl2_m1) {
+          if (widx > sample_ctl2_m1) {
+            break;
+          }
+          inner_loop_last = (sample_ct - 1) % kBitsPerWordD2;
+        }
+        uintptr_t genovec_word = 0;
+        uint32_t dosage_present_hw = 0;
+        for (uint32_t sample_idx_lowbits = 0; sample_idx_lowbits <= inner_loop_last; ++sample_idx_lowbits) {
+          if (unlikely(IsEolnKns(*dosage_iter))) {
+            goto MgfToPgen_ret_MISSING_TOKENS;
+          }
+          double cur_dosage;
+          char* token_end = ScanadvDouble(dosage_iter, &cur_dosage);
+          // BIMBAM writes "NA" for a missing call, and "-9" and "?"/"??" also
+          // show up in the wild.  Anything else has to parse as a dosage in
+          // [0, 2]; silently reading a typo as a missing call would be worse
+          // than refusing the file.
+          if ((!token_end) || (!IsSpaceOrEoln(*token_end)) || (cur_dosage < 0.0) || (cur_dosage > 2.0)) {
+            char* cur_token_end = CurTokenEnd(dosage_iter);
+            const uint32_t token_slen = cur_token_end - dosage_iter;
+            if (unlikely(!IsMgfMissingToken(dosage_iter, token_slen))) {
+              *cur_token_end = '\0';
+              snprintf(g_logbuf, kLogbufSize, "Error: Invalid dosage '%s' on line %" PRIuPTR " of %s.\n", dosage_iter, line_idx, mgfname);
+              goto MgfToPgen_ret_MALFORMED_INPUT_WW;
+            }
+            genovec_word |= (3 * k1LU) << (2 * sample_idx_lowbits);
+            dosage_iter = FirstNonTspace(cur_token_end);
+            continue;
+          }
+          dosage_iter = FirstNonTspace(token_end);
+          uint32_t dosage_int = S_CAST(int32_t, cur_dosage * kDosageMid + 0.5);
+          if (dosage_int > kDosageMax) {
+            dosage_int = kDosageMax;
+          }
+          const uint32_t cur_halfdist = BiallelicDosageHalfdist(dosage_int);
+          if (cur_halfdist < hard_call_halfdist) {
+            genovec_word |= (3 * k1LU) << (2 * sample_idx_lowbits);
+          } else {
+            genovec_word |= ((dosage_int + (kDosage4th * k1LU)) / kDosageMid) << (2 * sample_idx_lowbits);
+            if (cur_halfdist >= dosage_erase_halfdist) {
+              continue;
+            }
+          }
+          dosage_present_hw |= 1U << sample_idx_lowbits;
+          *dosage_main_iter++ = dosage_int;
+        }
+        genovec[widx] = genovec_word;
+        R_CAST(Halfword*, dosage_present)[widx] = dosage_present_hw;
+      }
+      if (sample_ctl2 % 2) {
+        R_CAST(Halfword*, dosage_present)[sample_ctl2] = 0;
+      }
+      const uint32_t dosage_ct = dosage_main_iter - dosage_main;
+      if (!dosage_ct) {
+        if (unlikely(SpgwAppendBiallelicGenovec(genovec, &spgw))) {
+          goto MgfToPgen_ret_WRITE_FAIL;
+        }
+      } else {
+        reterr = SpgwAppendBiallelicGenovecDosage16(genovec, dosage_present, dosage_main, dosage_ct, &spgw);
+        if (unlikely(reterr)) {
+          goto MgfToPgen_ret_1;
+        }
+      }
+      if (variant_idx >= next_print_idx) {
+        if (pct > 10) {
+          putc_unlocked('\b', stdout);
+        }
+        pct = (variant_idx * 100LLU) / variant_ct;
+        printf("\b\b%u%%", pct++);
+        fflush(stdout);
+        next_print_idx = (pct * S_CAST(uint64_t, variant_ct) + 99) / 100;
+      }
+    }
+    reterr = SpgwFinish(&spgw);
+    if (unlikely(reterr)) {
+      goto MgfToPgen_ret_1;
+    }
+    if (unlikely(CswriteCloseNull(&pvar_css, pvar_cswritep))) {
+      goto MgfToPgen_ret_WRITE_FAIL;
+    }
+    if (pct > 10) {
+      putc_unlocked('\b', stdout);
+    }
+    fputs("\b\b", stdout);
+    logputs("done.\n");
+    *outname_end = '\0';
+    logprintfww("--mgf: %s.pgen + %s.pvar%s + %s.psam written.\n", outname, outname, output_zst? ".zst" : "", outname);
+  }
+  while (0) {
+  MgfToPgen_ret_NOMEM:
+    reterr = kPglRetNomem;
+    break;
+  MgfToPgen_ret_OPEN_FAIL:
+    reterr = kPglRetOpenFail;
+    break;
+  MgfToPgen_ret_WRITE_FAIL:
+    reterr = kPglRetWriteFail;
+    break;
+  MgfToPgen_ret_TSTREAM_FAIL:
+    TextStreamErrPrint(cur_fname, &txs);
+    break;
+  MgfToPgen_ret_REWIND_FAIL:
+    logerrprintfww(kErrprintfRewind, cur_fname);
+    reterr = kPglRetRewindFail;
+    break;
+  MgfToPgen_ret_MISSING_TOKENS:
+    snprintf(g_logbuf, kLogbufSize, "Error: Line %" PRIuPTR " of %s has fewer tokens than expected.\n", line_idx, cur_fname);
+  MgfToPgen_ret_MALFORMED_INPUT_WW:
+    WordWrapB(0);
+    logerrputsb();
+    reterr = kPglRetMalformedInput;
+    break;
+  MgfToPgen_ret_INCONSISTENT_INPUT_WW:
+    WordWrapB(0);
+    logerrputsb();
+    reterr = kPglRetInconsistentInput;
+    break;
+  }
+ MgfToPgen_ret_1:
+  CswriteCloseCond(&pvar_css, pvar_cswritep);
+  CleanupSpgw(&spgw, &reterr);
+  CleanupTextStream2(cur_fname, &txs, &reterr);
+  fclose_cond(psamfile);
   BigstackDoubleReset(bigstack_mark, bigstack_end_mark);
   return reterr;
 }

--- a/2.0/plink2_import_legacy.cc
+++ b/2.0/plink2_import_legacy.cc
@@ -2461,7 +2461,7 @@ HEADER_INLINE void MgfCommasToSpaces(char* line_start) {
   }
 }
 
-PglErr MgfToPgen(const char* mgfname, const char* posname, const char* phenoname, MiscFlags misc_flags, ImportFlags import_flags, LoadFilterLogFlags load_filter_log_import_flags, uint32_t hard_call_thresh, uint32_t dosage_erase_thresh, uint32_t max_thread_ct, char* outname, char* outname_end, ChrInfo* cip) {
+PglErr MgfToPgen(const char* mgfname, const char* posname, const char* phenoname, const char* preexisting_psamname, const char* missing_catname, MiscFlags misc_flags, ImportFlags import_flags, LoadFilterLogFlags load_filter_log_import_flags, FamCol fam_cols, int32_t missing_pheno, uint32_t psam_01, uint32_t hard_call_thresh, uint32_t dosage_erase_thresh, uint32_t max_thread_ct, char* outname, char* outname_end, ChrInfo* cip) {
   unsigned char* bigstack_mark = g_bigstack_base;
   unsigned char* bigstack_end_mark = g_bigstack_end;
   FILE* psamfile = nullptr;
@@ -2615,9 +2615,23 @@ PglErr MgfToPgen(const char* mgfname, const char* posname, const char* phenoname
       goto MgfToPgen_ret_1;
     }
 
-    // 3. Write the .psam, with synthesized IDs and any phenotypes from the
-    //    .pheno.txt file.
-    {
+    // 3. Write the .psam.  With --psam/--fam the sample IDs (and phenotypes,
+    //    and sex) come from that file, which only has to have the right
+    //    number of rows since the .mgf carries no IDs of its own to match
+    //    against.  Otherwise they are synthesized, and 'pheno=' supplies the
+    //    phenotypes.
+    if (preexisting_psamname) {
+      uint32_t psam_sample_ct = 0;
+      reterr = RewritePsam(preexisting_psamname, missing_catname, misc_flags, fam_cols, missing_pheno, psam_01, max_thread_ct, outname, outname_end, &psam_sample_ct);
+      if (unlikely(reterr)) {
+        goto MgfToPgen_ret_1;
+      }
+      if (unlikely(psam_sample_ct != sample_ct)) {
+        snprintf(g_logbuf, kLogbufSize, "Error: %s has %u sample%s, while %s implies %u.\n", preexisting_psamname, psam_sample_ct, (psam_sample_ct == 1)? "" : "s", mgfname, sample_ct);
+        goto MgfToPgen_ret_INCONSISTENT_INPUT_WW;
+      }
+      logprintfww("--mgf: %u sample%s and %u variant%s present (sample IDs from %s).\n", sample_ct, (sample_ct == 1)? "" : "s", variant_ct, (variant_ct == 1)? "" : "s", preexisting_psamname);
+    } else {
       uint32_t pheno_col_ct = 0;
       char* pheno_lines = nullptr;
       uintptr_t max_pheno_line_blen = 0;

--- a/2.0/plink2_import_legacy.h
+++ b/2.0/plink2_import_legacy.h
@@ -62,6 +62,8 @@ PglErr Plink1SampleMajorToPgen(const char* pgenname, const uintptr_t* allele_fli
 
 PglErr PedmapToPgen(const char* pedname, const char* mapname, const char* missing_catname, MiscFlags misc_flags, ImportFlags import_flags, LoadFilterLogFlags load_filter_log_import_flags, uint32_t psam_01, FamCol fam_cols, int32_t missing_pheno, char input_missing_geno_char, uint32_t max_thread_ct, char* outname, char* outname_end, ChrInfo* cip);
 
+PglErr MgfToPgen(const char* mgfname, const char* posname, const char* phenoname, MiscFlags misc_flags, ImportFlags import_flags, LoadFilterLogFlags load_filter_log_import_flags, uint32_t hard_call_thresh, uint32_t dosage_erase_thresh, uint32_t max_thread_ct, char* outname, char* outname_end, ChrInfo* cip);
+
 #ifdef __cplusplus
 }  // namespace plink2
 #endif

--- a/2.0/plink2_import_legacy.h
+++ b/2.0/plink2_import_legacy.h
@@ -62,7 +62,7 @@ PglErr Plink1SampleMajorToPgen(const char* pgenname, const uintptr_t* allele_fli
 
 PglErr PedmapToPgen(const char* pedname, const char* mapname, const char* missing_catname, MiscFlags misc_flags, ImportFlags import_flags, LoadFilterLogFlags load_filter_log_import_flags, uint32_t psam_01, FamCol fam_cols, int32_t missing_pheno, char input_missing_geno_char, uint32_t max_thread_ct, char* outname, char* outname_end, ChrInfo* cip);
 
-PglErr MgfToPgen(const char* mgfname, const char* posname, const char* phenoname, MiscFlags misc_flags, ImportFlags import_flags, LoadFilterLogFlags load_filter_log_import_flags, uint32_t hard_call_thresh, uint32_t dosage_erase_thresh, uint32_t max_thread_ct, char* outname, char* outname_end, ChrInfo* cip);
+PglErr MgfToPgen(const char* mgfname, const char* posname, const char* phenoname, const char* preexisting_psamname, const char* missing_catname, MiscFlags misc_flags, ImportFlags import_flags, LoadFilterLogFlags load_filter_log_import_flags, FamCol fam_cols, int32_t missing_pheno, uint32_t psam_01, uint32_t hard_call_thresh, uint32_t dosage_erase_thresh, uint32_t max_thread_ct, char* outname, char* outname_end, ChrInfo* cip);
 
 #ifdef __cplusplus
 }  // namespace plink2


### PR DESCRIPTION
Follows up on #369, where you wrote that `--mgf` can be implemented in a separate PR. **Stacked on #369**: the first commit here belongs to that branch, so this diff only reads cleanly once #369 lands.

BIMBAM's mean genotype format is one of the formats PLINK 1.9 could write but never read, so a dataset exported to it could not be brought back. `--export mgf` is in #369; this is the reader.

```
--mgf <.mgf file> <.pos.txt file> ['pheno='<.pheno.txt file>]
```

The .mgf has one row per variant (ID, ALT, REF, then one ALT dosage per sample). The .pos.txt gives each variant's ID, bp coordinate and chromosome in any order, so it is read into a hash table first and the .mgf is then streamed in a single pass. Commas are accepted in place of whitespace in both, since that is what BIMBAM itself writes.

Neither file carries sample IDs, so `per0`, `per1`, ... are synthesized as `--dummy` does. `pheno=` names a file with one row per sample whose columns become PHENO1, PHENO2, ...; its row count is checked against the sample count the .mgf implies.

Dosages are imported at full precision and reduced to hardcalls by the usual `--hard-call-threshold` / `--dosage-erase-threshold` rules.

One judgment call worth flagging: `NA`, `-9`, `?`, `??` and `.` mark a missing call, and anything else that is not a number in [0, 2] is an error rather than a silent missing call. Treating an unparseable token as missing would quietly drop data on a malformed file, which seemed worse than refusing it. Easy to relax if you would rather match BIMBAM's own leniency.

`Tests/TEST_MGF` covers the `--export mgf` round trip on hardcalls and on dosages (byte-identical .mgf, .pos.txt and .pvar both ways, and the synthesized .psam), the comma-delimited and bgzipped forms, each missing-value spelling, `pheno=`, and six malformed-input cases including the line numbers the errors cite.

The first commit removes a `ChrInfo` parameter that `ExportBeagle` stopped using when the chromosome-split form was retired in #369; it was tripping `-Wunused-parameter` along with two dead locals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)