### PR TITLE
--flip-scan: take an optional case/control phenotype name

### DIFF
--- a/2.0/Tests/TEST_FLIP_SCAN/run_tests.sh
+++ b/2.0/Tests/TEST_FLIP_SCAN/run_tests.sh
@@ -159,3 +159,44 @@ if $BUILD/plink2 $EXTRA1 $EXTRA2 --bfile tmp_data --flip-scan-ref-freq tmp_panel
     echo "--flip-scan-ref-freq ran without --flip-scan"
     exit 1
 fi
+
+# 9. Which case/control phenotype to split on is named explicitly once more
+#    than one is loaded.
+printf '#FID\tIID\tCC1\tCC2\tQT\n' > tmp_multi_ph.txt
+awk '{print $1, $2, ((NR > 200)? 2 : 1), ((NR % 2)? 2 : 1), (NR % 5)}' OFS='\t' tmp_data.fam >> tmp_multi_ph.txt
+
+# One loaded phenotype: the name stays optional.
+$BUILD/plink2 $EXTRA1 $EXTRA2 --bfile tmp_data --pheno tmp_multi_ph.txt --pheno-name CC1 --maf 0.05 --flip-scan --out plink2_p1
+# ...and naming it gives the same answer.
+$BUILD/plink2 $EXTRA1 $EXTRA2 --bfile tmp_data --pheno tmp_multi_ph.txt --maf 0.05 --flip-scan CC1 --out plink2_p1n
+diff -q plink2_p1.flipscan plink2_p1n.flipscan
+
+# Two loaded, no name: refused rather than picking one.
+if $BUILD/plink2 $EXTRA1 $EXTRA2 --bfile tmp_data --pheno tmp_multi_ph.txt --maf 0.05 --flip-scan --out plink2_bad > /dev/null 2>&1; then
+    echo "ambiguous phenotype accepted"
+    exit 1
+fi
+
+# The name actually selects: CC2 splits the samples differently from CC1, so
+# the two reports have to differ.
+$BUILD/plink2 $EXTRA1 $EXTRA2 --bfile tmp_data --pheno tmp_multi_ph.txt --maf 0.05 --flip-scan CC2 --out plink2_p2
+if cmp -s plink2_p1n.flipscan plink2_p2.flipscan; then
+    echo "CC1 and CC2 gave identical reports; the name is being ignored"
+    exit 1
+fi
+
+# A name is still just one more argument, so it coexists with the modifiers.
+$BUILD/plink2 $EXTRA1 $EXTRA2 --bfile tmp_data --pheno tmp_multi_ph.txt --maf 0.05 --flip-scan verbose CC2 --out plink2_p2v
+diff -q plink2_p2.flipscan plink2_p2v.flipscan
+test -f plink2_p2v.flipscan.verbose
+
+# A quantitative phenotype cannot define cases, and an unknown name is not
+# silently ignored.
+if $BUILD/plink2 $EXTRA1 $EXTRA2 --bfile tmp_data --pheno tmp_multi_ph.txt --maf 0.05 --flip-scan QT --out plink2_bad > /dev/null 2>&1; then
+    echo "quantitative phenotype accepted"
+    exit 1
+fi
+if $BUILD/plink2 $EXTRA1 $EXTRA2 --bfile tmp_data --pheno tmp_multi_ph.txt --maf 0.05 --flip-scan NOSUCH --out plink2_bad > /dev/null 2>&1; then
+    echo "unknown phenotype name accepted"
+    exit 1
+fi

--- a/2.0/plink2.cc
+++ b/2.0/plink2.cc
@@ -3046,7 +3046,7 @@ PglErr Plink2Core(const Plink2Cmdline* pcp, MakePlink2Flags make_plink2_flags, c
         if (pcp->ld_info.flipscan_ref_freq_fname) {
           reterr = FlipScanRefFreq(variant_include, cip, variant_bps, variant_ids, allele_idx_offsets, allele_storage, allele_freqs, &(pcp->ld_info), raw_variant_ct, variant_ct, max_allele_ct, max_variant_id_slen, max_allele_slen, pcp->max_thread_ct, outname, outname_end);
         } else {
-          reterr = FlipScan(sample_include, sex_male, pheno_cols, variant_include, cip, variant_bps, variant_ids, allele_idx_offsets, allele_storage, allele_freqs, founder_info, &(pcp->ld_info), raw_sample_ct, pheno_ct, (pcp->misc_flags / kfMiscAllowBadLd) & 1, pcp->max_thread_ct, &simple_pgr, outname, outname_end);
+          reterr = FlipScan(sample_include, sex_male, pheno_cols, pheno_names, variant_include, cip, variant_bps, variant_ids, allele_idx_offsets, allele_storage, allele_freqs, founder_info, &(pcp->ld_info), raw_sample_ct, pheno_ct, max_pheno_name_blen, (pcp->misc_flags / kfMiscAllowBadLd) & 1, pcp->max_thread_ct, &simple_pgr, outname, outname_end);
         }
         if (unlikely(reterr)) {
           goto Plink2Core_ret_1;
@@ -6807,6 +6807,13 @@ int main(int argc, char** argv) {
                 goto main_ret_INVALID_CMDLINE;
               }
               reterr = ParseColDescriptor(&(cur_modif[5]), "chrom\0pos\0ref\0alt\0altfreq\0posct\0rpos\0negct\0rneg\0negids\0majfreq\0problem\0", "flip-scan", kfFlipScanColChrom, kfFlipScanColDefault, 1, &pc.ld_info.flipscan_flags);
+              if (unlikely(reterr)) {
+                goto main_ret_1;
+              }
+            } else if (likely(!pc.ld_info.flipscan_phenoname)) {
+              // Anything else is taken as the case/control phenotype to split
+              // on, the way --cmh takes its phenotype name.
+              reterr = CmdlineAllocString(cur_modif, argvk[arg_idx], kMaxIdSlen, &pc.ld_info.flipscan_phenoname);
               if (unlikely(reterr)) {
                 goto main_ret_1;
               }

--- a/2.0/plink2_help.cc
+++ b/2.0/plink2_help.cc
@@ -1102,7 +1102,7 @@ PglErr DispHelp(const char* const* argvk, uint32_t param_ct) {
               );
     HelpPrint("flip-scan\0flipscan\0", &help_ctrl, 1,
 "  --flip-scan ['verbose'] ['zs'] ['ref-allele-based']\n"
-"              [{'cols='<column set descriptor>}]\n"
+"              [{'cols='<column set descriptor>}] [phenotype name]\n"
 "    (alias: --flipscan)\n"
 "    Scan for case/control strand inconsistency, in two steps.\n"
 "    1. A variant whose major-allele frequency differs between the two groups\n"
@@ -1118,6 +1118,8 @@ PglErr DispHelp(const char* const* argvk, uint32_t param_ct) {
 "      exceeds --flip-scan-max-maj-freq (default 0.9), take no part in the LD\n"
 "      scan in either role, so the window is spent on variants that inform.\n"
 "    * A case/control phenotype is required, and only founders are considered.\n"
+"      Name it when more than one is loaded; with exactly one, the name may\n"
+"      be omitted.\n"
 "      The LD scan needs at least 50 founders in each group; --bad-ld runs it\n"
 "      anyway.\n"
 "    * \'ref-allele-based\' reports REF frequencies rather than major-allele\n"

--- a/2.0/plink2_ld.cc
+++ b/2.0/plink2_ld.cc
@@ -63,6 +63,7 @@ void InitLd(LdInfo* ldip) {
   // rate down.
   ldip->flipscan_min_neg_ct = 2;
   ldip->flipscan_ref_freq_fname = nullptr;
+  ldip->flipscan_phenoname = nullptr;
   ldip->prune_window_size = 0;
   ldip->prune_window_incr = 0;
   ldip->prune_last_param = 0.0;
@@ -75,6 +76,7 @@ void CleanupLd(LdInfo* ldip) {
   free_cond(ldip->ld_console_varids[0]);
   free_cond(ldip->ld_console_varids[1]);
   free_cond(ldip->flipscan_ref_freq_fname);
+  free_cond(ldip->flipscan_phenoname);
 }
 
 void InitClump(ClumpInfo* clump_ip) {
@@ -14357,7 +14359,7 @@ PglErr FlipScanRefFreq(const uintptr_t* variant_include, const ChrInfo* cip, con
   return reterr;
 }
 
-PglErr FlipScan(const uintptr_t* orig_sample_include, const uintptr_t* sex_male, const PhenoCol* pheno_cols, const uintptr_t* variant_include, const ChrInfo* cip, const uint32_t* variant_bps, const char* const* variant_ids, const uintptr_t* allele_idx_offsets, const char* const* allele_storage, const double* allele_freqs, const uintptr_t* founder_info, const LdInfo* ldip, uint32_t raw_sample_ct, uint32_t pheno_ct, uint32_t allow_bad_ld, uint32_t max_thread_ct, PgenReader* simple_pgrp, char* outname, char* outname_end) {
+PglErr FlipScan(const uintptr_t* orig_sample_include, const uintptr_t* sex_male, const PhenoCol* pheno_cols, const char* pheno_names, const uintptr_t* variant_include, const ChrInfo* cip, const uint32_t* variant_bps, const char* const* variant_ids, const uintptr_t* allele_idx_offsets, const char* const* allele_storage, const double* allele_freqs, const uintptr_t* founder_info, const LdInfo* ldip, uint32_t raw_sample_ct, uint32_t pheno_ct, uintptr_t max_pheno_name_blen, uint32_t allow_bad_ld, uint32_t max_thread_ct, PgenReader* simple_pgrp, char* outname, char* outname_end) {
   unsigned char* bigstack_mark = g_bigstack_base;
   char* cswritep = nullptr;
   char* cswritep_verbose = nullptr;
@@ -14369,19 +14371,40 @@ PglErr FlipScan(const uintptr_t* orig_sample_include, const uintptr_t* sex_male,
   PreinitThreads(&tg);
   PglErr reterr = kPglRetSuccess;
   {
+    const char* flipscan_phenoname = ldip->flipscan_phenoname;
     const PhenoCol* cc_pheno_col = nullptr;
-    for (uint32_t pheno_idx = 0; pheno_idx != pheno_ct; ++pheno_idx) {
-      if (pheno_cols[pheno_idx].type_code == kPhenoDtypeCc) {
-        if (unlikely(cc_pheno_col)) {
-          logerrputs("Error: --flip-scan requires a phenotype name to be specified when multiple\ncase/control phenotypes are defined.\n");
-          goto FlipScan_ret_INCONSISTENT_INPUT;
+    if (flipscan_phenoname) {
+      const uint32_t pheno_blen = strlen(flipscan_phenoname) + 1;
+      if (pheno_blen <= max_pheno_name_blen) {
+        for (uint32_t pheno_idx = 0; pheno_idx != pheno_ct; ++pheno_idx) {
+          if (memequal(flipscan_phenoname, &(pheno_names[pheno_idx * max_pheno_name_blen]), pheno_blen)) {
+            cc_pheno_col = &(pheno_cols[pheno_idx]);
+            break;
+          }
         }
-        cc_pheno_col = &(pheno_cols[pheno_idx]);
       }
-    }
-    if (unlikely(!cc_pheno_col)) {
-      logerrputs("Error: --flip-scan requires a case/control phenotype.\n");
-      goto FlipScan_ret_INCONSISTENT_INPUT;
+      if (unlikely(!cc_pheno_col)) {
+        logerrprintfww("Error: --flip-scan phenotype '%s' not found.\n", flipscan_phenoname);
+        goto FlipScan_ret_INCONSISTENT_INPUT;
+      }
+      if (unlikely(cc_pheno_col->type_code != kPhenoDtypeCc)) {
+        logerrprintfww("Error: --flip-scan phenotype '%s' is not case/control.\n", flipscan_phenoname);
+        goto FlipScan_ret_INCONSISTENT_INPUT;
+      }
+    } else {
+      for (uint32_t pheno_idx = 0; pheno_idx != pheno_ct; ++pheno_idx) {
+        if (pheno_cols[pheno_idx].type_code == kPhenoDtypeCc) {
+          if (unlikely(cc_pheno_col)) {
+            logerrputs("Error: --flip-scan requires a phenotype name to be specified when multiple\ncase/control phenotypes are defined.\n");
+            goto FlipScan_ret_INCONSISTENT_INPUT;
+          }
+          cc_pheno_col = &(pheno_cols[pheno_idx]);
+        }
+      }
+      if (unlikely(!cc_pheno_col)) {
+        logerrputs("Error: --flip-scan requires a case/control phenotype.\n");
+        goto FlipScan_ret_INCONSISTENT_INPUT;
+      }
     }
     const uint32_t raw_sample_ctl = BitCtToWordCt(raw_sample_ct);
     uintptr_t* base_include;

--- a/2.0/plink2_ld.h
+++ b/2.0/plink2_ld.h
@@ -155,6 +155,7 @@ typedef struct LdInfoStruct {
   // When set, --flip-scan compares the dataset against these frequencies
   // instead of splitting it into cases and controls.
   char* flipscan_ref_freq_fname;
+  char* flipscan_phenoname;
 } LdInfo;
 
 typedef struct ClumpInfoStruct {
@@ -241,7 +242,7 @@ void CleanupVcor(VcorInfo* vcip);
 
 PglErr FlipScanRefFreq(const uintptr_t* variant_include, const ChrInfo* cip, const uint32_t* variant_bps, const char* const* variant_ids, const uintptr_t* allele_idx_offsets, const char* const* allele_storage, const double* allele_freqs, const LdInfo* ldip, uint32_t raw_variant_ct, uint32_t variant_ct, uint32_t max_allele_ct, uint32_t max_variant_id_slen, uint32_t max_allele_slen, uint32_t max_thread_ct, char* outname, char* outname_end);
 
-PglErr FlipScan(const uintptr_t* orig_sample_include, const uintptr_t* sex_male, const PhenoCol* pheno_cols, const uintptr_t* variant_include, const ChrInfo* cip, const uint32_t* variant_bps, const char* const* variant_ids, const uintptr_t* allele_idx_offsets, const char* const* allele_storage, const double* allele_freqs, const uintptr_t* founder_info, const LdInfo* ldip, uint32_t raw_sample_ct, uint32_t pheno_ct, uint32_t allow_bad_ld, uint32_t max_thread_ct, PgenReader* simple_pgrp, char* outname, char* outname_end);
+PglErr FlipScan(const uintptr_t* orig_sample_include, const uintptr_t* sex_male, const PhenoCol* pheno_cols, const char* pheno_names, const uintptr_t* variant_include, const ChrInfo* cip, const uint32_t* variant_bps, const char* const* variant_ids, const uintptr_t* allele_idx_offsets, const char* const* allele_storage, const double* allele_freqs, const uintptr_t* founder_info, const LdInfo* ldip, uint32_t raw_sample_ct, uint32_t pheno_ct, uintptr_t max_pheno_name_blen, uint32_t allow_bad_ld, uint32_t max_thread_ct, PgenReader* simple_pgrp, char* outname, char* outname_end);
 
 PglErr LdPrune(const uintptr_t* orig_variant_include, const ChrInfo* cip, const uint32_t* variant_bps, const char* const* variant_ids, const uintptr_t* allele_idx_offsets, const AlleleCode* maj_alleles, const double* allele_freqs, const uintptr_t* founder_info, const uintptr_t* sex_nm, const uintptr_t* sex_male, const LdInfo* ldip, const char* indep_preferred_fname, uint32_t raw_variant_ct, uint32_t variant_ct, uint32_t raw_sample_ct, uint32_t founder_ct, uint32_t nosex_ct, uint32_t max_thread_ct, PgenReader* simple_pgrp, char* outname, char* outname_end);
 


### PR DESCRIPTION
The phenotype-name half of what you left open in ede5d76d, which made `--flip-scan` refuse to guess once more than one case/control phenotype is loaded. This gives it the way to say which one.

```
--flip-scan ['verbose'] ['zs'] ['ref-allele-based'] [cols=...] [phenotype name]
```

Same shape `--cmh` takes its name in, and `--twolocus` in #395.

## Behavior

- With exactly one case/control phenotype loaded, the name stays optional -- there is nothing to disambiguate, so the error only fires when a choice actually has to be made.
- Naming that sole phenotype gives the same report as not naming it.
- A name matching no phenotype, or naming one that is not case/control, is an error rather than a silent fallback to the scan.

```
$ plink2 --bfile d --pheno ph.txt --flip-scan
Error: --flip-scan requires a phenotype name to be specified when multiple
case/control phenotypes are defined.

$ plink2 --bfile d --pheno ph.txt --flip-scan QT
Error: --flip-scan phenotype 'QT' is not case/control.

$ plink2 --bfile d --pheno ph.txt --flip-scan NOSUCH
Error: --flip-scan phenotype 'NOSUCH' not found.
```

`FlipScan()` needed `pheno_names`/`max_pheno_name_blen` to resolve by name; that is the only signature change.

## Tests

`Tests/TEST_FLIP_SCAN` gains both error paths, a check that naming the sole phenotype matches not naming it, and a check that `CC1` and `CC2` produce *different* reports -- without that last one the argument could be parsed and then ignored, and the suite would not notice.

Categorical phenotypes are not covered here; happy to add them as a follow-up if you still want them, along the lines of #395.

🤖 Generated with [Claude Code](https://claude.com/claude-code)