### PR TITLE
1.9: stop --distance from writing a matrix of NaN

### DIFF
--- a/1.9/plink_calc.c
+++ b/1.9/plink_calc.c
@@ -7761,6 +7761,14 @@ int32_t calc_distance(pthread_t* threads, uint32_t parallel_idx, uint32_t parall
     // performance becomes less important than accuracy on 50+ million marker
     // sets.)
     // subtract marker_ct to guard against rounding-driven overflow
+    if (!(dyy > 0.0)) {
+      // Every remaining variant is monomorphic, so every weight is zero.  The
+      // division below then gives infinity, and 0 * infinity is NaN, which the
+      // cast to uint32_t makes undefined.
+      logerrprint("Error: No variant has positive weight; --distance cannot be computed.\n");
+      retval = RET_DEGENERATE_DATA;
+      goto calc_distance_ret_1;
+    }
     dyy = (4294967296.0 - ((double)((intptr_t)marker_ct))) / dyy;
     for (marker_idx = 0; marker_idx < marker_ct; marker_idx++) {
       uii = (uint32_t)(dist_missing_wts[marker_idx] * dyy + 0.5);


### PR DESCRIPTION
Part of the validation pass for #399, and the only piece that changes what a run produces rather than what it does wrong. Sent separately for that reason.

On a variant set where every remaining variant is monomorphic, every per-marker weight is zero, so their sum is zero, so

```c
dyy = (4294967296.0 - ((double)((intptr_t)marker_ct))) / dyy;
```

is infinity, and `0 * infinity` is NaN. The cast to `uint32_t` on the next line is undefined, and the run finishes by writing a distance matrix whose every entry is `nan`:

```
$ plink --bfile allmono --distance
Distances (allele counts) written to plink.dist .
$ head -2 plink.dist
nan
nan	nan
```

Reachable after any aggressive MAF filter, not only with hand-made input.

This stops with an error instead. **That is a judgment call and I would rather you made it**: warning and carrying on is defensible too, and so is emitting zeros. What is not in question is that the current output is unusable and the cast is undefined.

I notice the `dxx == 1.0` bugfix dated 7 Sep 2026 sits a few lines above this, so you were recently in exactly this block; this is the adjacent case where the sum reaches zero rather than a single frequency reaching one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
