### PR TITLE
2.0: fix a 64-bit shift by the full nyp count in SetTrailingNyps()

### DIFF
--- a/2.0/include/pgenlib_misc.h
+++ b/2.0/include/pgenlib_misc.h
@@ -321,7 +321,12 @@ HEADER_INLINE void ZeroTrailingNyps(uintptr_t nyp_ct, uintptr_t* bitarr) {
 HEADER_INLINE void SetTrailingNyps(uintptr_t nyp_ct, uintptr_t* bitarr) {
   const uintptr_t trail_ct = nyp_ct % kBitsPerWordD2;
   if (trail_ct) {
-    bitarr[nyp_ct / kBitsPerWordD2] |= (~k0LU) << (nyp_ct * 2);
+    // Shift by trail_ct * 2, not nyp_ct * 2.  The two agree on x86-64 and
+    // ARM64, where the shift count is masked to 6 bits and (nyp_ct * 2) % 64
+    // is exactly trail_ct * 2, but a shift that wide is undefined, and it is
+    // wrong on any target that does not mask.  ZeroTrailingBits() next door
+    // already uses the remainder.
+    bitarr[nyp_ct / kBitsPerWordD2] |= (~k0LU) << (trail_ct * 2);
   }
 }
 


### PR DESCRIPTION
Starting the same validation pass on 2.0 that #403-#406 did for 1.9, now that it is in beta. This is the first thing it found.

```c
HEADER_INLINE void SetTrailingNyps(uintptr_t nyp_ct, uintptr_t* bitarr) {
  const uintptr_t trail_ct = nyp_ct % kBitsPerWordD2;
  if (trail_ct) {
    bitarr[nyp_ct / kBitsPerWordD2] |= (~k0LU) << (nyp_ct * 2);
  }
}
```

The shift uses the full count rather than the remainder, so it is a shift by 4000 on a 2000-sample file. It produces the right answer on x86-64 and ARM64, because the shift count is masked to 6 bits there and `(nyp_ct * 2) % 64` is exactly `trail_ct * 2`. It is still undefined, and it is wrong on any target that does not mask. `ZeroTrailingBits()` a few lines away already uses the remainder, which is what makes this look like an oversight rather than a deliberate reliance on masking.

UBSan reports it on an ordinary run; `--distance`, `--distance-matrix`, `--ibs-matrix`, `--make-king`, `--make-king-table` and `--king-cutoff` all reach it.

No output change, as the above implies: 145 output files compared against a build of current master over seven datasets and 22 commands, all identical, and `2.0/Tests` passes.

**One thing I want to be explicit about**, since it came out of the same sweep and I am deliberately *not* reporting it as a bug. ASan flags `Rawmemchr()` and `ReplaceCharAdvChecked()` as heap-buffer-overflow reads of 16 bytes, from `--clump` and `--sample-diff`. Those are the aligned-vector scan idiom: the address is rounded down to a vector boundary and the extra bytes are masked off. Since an aligned vector read cannot cross a page boundary, it is safe, and ASan only objects because it tracks malloc extents rather than pages. I mention it so that if you run ASan yourself you know those two are accounted for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
