### PR TITLE
2.0: fix --export bgen-1.2/1.3 aborting on small variant records

### DIFF
--- a/2.0/plink2_export.cc
+++ b/2.0/plink2_export.cc
@@ -2900,7 +2900,13 @@ PglErr ExportBgen13(const char* outname, const uintptr_t* sample_include, uint32
         goto ExportBgen13_ret_INCONSISTENT_INPUT;
       }
       if (!use_zstd_compression) {
-        bgen_compressed_buf_max = libdeflate_deflate_compress_bound(nullptr, bgen_geno_buf_size);
+        // zlib, not raw deflate: the compression call below is
+        // libdeflate_zlib_compress(), which adds a 2-byte header and a 4-byte
+        // Adler-32 trailer.  The deflate bound leaves no room for those, and
+        // libdeflate then returns 0 because the output does not fit.  Large
+        // variants have enough slack to hide it; small ones do not.  The
+        // BGEN 1.1 path a thousand lines up already uses the zlib bound.
+        bgen_compressed_buf_max = libdeflate_zlib_compress_bound(nullptr, bgen_geno_buf_size);
       } else {
         bgen_compressed_buf_max = ZSTD_compressBound(bgen_geno_buf_size);
       }


### PR DESCRIPTION
Second thing the 2.0 validation pass turned up, and this one is a crash on ordinary data.

```
$ plink2 --bfile tiny --export bgen-1.2
Assertion failed: (compressed_bytect), function ExportBgen13Thread,
file plink2_export.cc, line 2730.
```

`tiny` there is an unmodified two-sample, two-variant fileset. It also reproduces on a one-sample/one-variant set, a three-sample set whose variants are monomorphic, and a four-sample chrX/chrY/chrMT set. All four abort on current master.

The cause:

```c
bgen_compressed_buf_max = libdeflate_deflate_compress_bound(nullptr, bgen_geno_buf_size);
...
compressed_bytect = libdeflate_zlib_compress(compressor, uncompressed_bgen_geno_buf,
                                             uncompressed_bytect, writebuf_iter,
                                             bgen_compressed_buf_max);
```

The bound is the raw deflate bound; the call produces zlib, which adds a 2-byte header and a 4-byte Adler-32 trailer. Six bytes the bound does not account for, so libdeflate returns 0 because the output does not fit. A large variant record compresses far enough below the bound that the slack absorbs it, which is why this only shows up on small ones.

The `assert()` two lines below is what makes the symptom an abort. Without assertions it would write a variant record announcing four bytes of payload it never wrote, which seems worse than crashing.

The BGEN 1.1 path already uses `libdeflate_zlib_compress_bound()`, which is what makes this look like an oversight rather than a deliberate choice.

Found by fuzzing mutated filesets against random flag combinations under ASan and UBSan, then reduced to the unmutated datasets above.

Verification: the `.bgen` output is byte-identical to master's on the datasets that already worked, the previously failing ones now round-trip back through `--bgen` with the right variant counts, and `2.0/Tests` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
