### PR TITLE
2.0: fix kfLoadFilterLogExcludePalindromicSnps's bit index

### DIFF
--- a/2.0/plink2_common.h
+++ b/2.0/plink2_common.h
@@ -302,7 +302,7 @@ FLAGSET_DEF_START()
   kfLoadFilterLogImportMergeMask = ((kfLoadFilterLogImportMergeAlreadyApplied * 2) - kfLoadFilterLogImportMaxAlleles),
   // main .pvar load only
   kfLoadFilterLogExcludeIfInfo = (1 << 9),
-  kfLoadFilterLogExcludePalindromicSnps = (1 << 19),
+  kfLoadFilterLogExcludePalindromicSnps = (1 << 10),
   kfLoadFilterLogExtractIfInfo = (1 << 11),
   kfLoadFilterLogMaxAlleles = (1 << 12),
   kfLoadFilterLogMinAlleles = (1 << 13),


### PR DESCRIPTION
Fifth from the 2.0 validation pass, and the first one with a symptom a user would actually notice.

```c
  kfLoadFilterLogExcludeIfInfo = (1 << 9),
  kfLoadFilterLogExcludePalindromicSnps = (1 << 19),
  kfLoadFilterLogExtractIfInfo = (1 << 11),
```

Bit 10 is what the sequence calls for, and what `kLoadFilterLogFlagnames[]` matches: its eleventh entry is `"exclude-palindromic-snps"`, between `"exclude-if-info"` and `"extract-if-info"`, exactly where the neighbouring flags put them. Bit 10 is otherwise unused, and nothing else in the set goes past 18.

`AppendLoadFilterFlagnames()` indexes that 19-entry table by bit position, so `--exclude-palindromic-snps` reads one element past the end. The bytes after the table happen to begin with a NUL, so the symptom is a log line with the flag name missing:

```
$ plink2 --bfile base --exclude-palindromic-snps --make-just-pvar
400 variants loaded from base.bim (-- had no effect).
```

and with this change:

```
400 variants loaded from base.bim (--exclude-palindromic-snps had no effect).
```

ASan reports the read as a global-buffer-overflow.

Nothing else depends on the value: `ImportMask`, `MergeMask` and `ImportMergeMask` are built from bits 0 through 8, so neither 19 nor 10 falls inside them, and the filtering itself is unaffected. I checked that too: `.pvar` output is identical to master's on three datasets, and `2.0/Tests` passes.

Found by fuzzing random flag combinations under ASan, then reduced to plain valid input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
