### PR TITLE
Avoid undefined shift in GetVint31() on malformed varints

### DIFF
--- a/2.0/include/plink2_base.h
+++ b/2.0/include/plink2_base.h
@@ -2324,8 +2324,12 @@ HEADER_INLINE uint32_t GetVint31(const unsigned char* buf_end, const unsigned ch
         return vint32;
       }
       shift += 7;
-      // currently don't check for shift >= 32 (that's what ValidateVint31()
-      // is for).
+      if (unlikely(shift == 35)) {
+        // Value doesn't fit in 31 bits, so it can't be legitimate; report it
+        // the same way as read-past-end, instead of shifting by >= 32 (which
+        // is undefined behavior).  ValidateVint31() has the same cutoff.
+        return 0x80000000U;
+      }
     }
   }
   return 0x80000000U;


### PR DESCRIPTION
## Problem

`GetVint31()` in `2.0/include/plink2_base.h` accumulates a varint with no upper bound on its shift counter:

```c
      shift += 7;
      // currently don't check for shift >= 32 (that's what ValidateVint31()
      // is for).
```

A varint with six or more continuation bytes therefore evaluates `(uii & 127) << 35` on a `uint32_t`, which is undefined behavior. On x86-64 and ARM64 the shift count is masked to 5 bits, so instead of being rejected the value silently wraps into an arbitrary small number, and the caller proceeds with it.

The comment points at `ValidateVint31()`, but that function is only reached from the `--validate`-style pass. The ordinary read path (`ParseDifflistHeader` -> `ParseAndApplyDifflist` -> `ReadRawGenovec`) calls `GetVint31()` directly, so a corrupted `.pgen` reaches the unchecked shift.

## Reproducer

Corrupt a byte inside a difflist-encoded record of a `.pgen` and run `--freq`, built with `-fsanitize=undefined`:

```
../include/plink2_base.h:2322:29: runtime error: shift exponent 35 is too large for 32-bit type 'uint32_t' (aka 'unsigned int')
    #0 plink2::GetVint31(unsigned char const*, unsigned char const**) plink2_base.h:2322
    #1 plink2::ParseDifflistHeader(...) pgenlib_read.cc:2190
    #2 plink2::ParseAndApplyDifflist(...) pgenlib_read.cc:2514
    #3 plink2::ReadRawGenovec(...) pgenlib_read.cc:2993
    #4 plink2::GetBasicGenotypeCountsAndDosage16s(...) pgenlib_read.cc:7966
    #5 plink2::LoadAlleleAndGenoCountsThread(void*) plink2_data.cc:2424
```

Found by a sanitizer sweep over corrupted dosage/multiallelic `.pgen` inputs.

## Fix

A shift of 35 or more can only arise for a value that does not fit in 31 bits, so it can never be a legitimate vint31. Return the existing `0x80000000U` sentinel, which callers already treat as failure (`ParseDifflistHeader`'s range check is commented "automatically catches GetVint31() failure"). This is the same cutoff `ValidateVint31()` uses.

## Verification

Same input after the patch, no sanitizer report, ordinary diagnostic instead:

```
Error: Failed to unpack (0-based) variant #13 in .pgen file.
```

`2.0/Tests/run_tests.sh` passes in full against a clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)