### PR TITLE
Fix --annotate segfault with 'block' and attrib= but no ranges=

### DIFF
--- a/1.9/plink_set.c
+++ b/1.9/plink_set.c
@@ -2847,6 +2847,18 @@ int32_t annotate(const Annot_info* aip, uint32_t allow_extra_chroms, char* outna
       unique_annot_ct = write_idx + 1;
     } else {
       unique_annot_ct = attr_id_ct;
+      // Without ranges=, the attribute IDs are already in the order the header
+      // line is written in, so the remap is the identity.  It still has to
+      // exist: the annotation loop below indexes attr_id_remap[] without
+      // checking for null.
+      if (attr_id_ct) {
+	if (bigstack_alloc_ui(attr_id_ct, &attr_id_remap)) {
+	  goto annotate_ret_NOMEM;
+	}
+	for (ulii = 0; ulii < attr_id_ct; ulii++) {
+	  attr_id_remap[ulii] = 2 * ((uint32_t)ulii) + 1;
+	}
+      }
     }
 #ifdef __LP64__
     unique_annot_ctlw = (unique_annot_ct + 3) / 4;


### PR DESCRIPTION
## Problem

`--annotate <report> attrib=<file> block` segfaults on entirely valid input.

`attr_id_remap` is only assigned inside the `ranges=` branch, where it is carved out of `range_idx_lookup`:

```c
  if (block01) {
    ulii = attr_id_ct + range_ct;
    if (range_names) {
      ...
      if (bigstack_alloc_ui(ulii, &range_idx_lookup)) { ... }
      if (attr_id_ct) {
        attr_id_remap = &(range_idx_lookup[range_ct]);
      }
      ...
    } else {
      unique_annot_ct = attr_id_ct;      // <- nothing allocated
    }
```

but the annotation loop indexes it unconditionally:

```c
        writebuf[attr_id_remap[uii + ujj]] = '1';
```

So with `block` and an `attrib=` file but no `ranges=` file, the first matching attribute dereferences a null pointer.

## Reproducer

```
$ plink --annotate plink.assoc attrib=attrs.txt block
Segmentation fault
$ echo $?
139
```

Reproduced on the released b.7.11 binary and on current master. With `-fsanitize=undefined`:

```
plink_set.c:3165:12: runtime error: applying non-zero offset 4 to null pointer
plink_set.c:3165:12: runtime error: load of address 0x000000000004 with insufficient space
                     for an object of type 'uint32_t'
```

## Fix

Without `ranges=`, the header line is written straight out of `sorted_attr_ids` in order:

```c
    if (!range_ct) {
      for (ulii = 0; ulii < attr_id_ct; ulii++) {
        putc_unlocked(' ', outfile);
        fputs(&(sorted_attr_ids[ulii * max_attr_id_len]), outfile);
      }
```

so attribute k always lands in output column k, which is offset `2k + 1` in `writebuf` (the buffer is prefilled with repeated `" 0"`, and the `'1'` overwrites the digit). Allocate the table in that branch as well and fill it with that identity mapping, keeping the inner loop branch-free.

## Verification

Output on a three-attribute file, where `null_0` carries `grp1`:

```
 CHR      SNP         BP   A1  ...        OR  grp0 grp1 grp2
   1   null_0          1    D  ...      1.01   0 1 0
```

- The `ranges=` path is byte-identical to master.
- 466 output files compared across 129 command lines and 4 datasets: no differences.

Found by a randomized sanitizer fuzz of the report-based tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)