### PR TITLE
Fix misaligned uint32 read in --dosage ... occur

### DIFF
--- a/1.9/plink_dosage.c
+++ b/1.9/plink_dosage.c
@@ -2284,7 +2284,10 @@ int32_t plink1_dosage(Dosage_info* doip, char* famname, char* mapname, char* out
 	bufptr2 = &(bufptr[ulii * max_occur_id_len]);
 	slen = strlen(bufptr2);
 	pzwritep = memcpyax(pzwritep, bufptr2, slen, ' ');
-	pzwritep = uint32toa(*((uint32_t*)(&(bufptr2[slen + 1]))), pzwritep);
+	// The count sits right after the variable-length ID, so it is not
+	// 4-byte aligned; read it the same way it was written above.
+	memcpy(&uii, &(bufptr2[slen + 1]), sizeof(int32_t));
+	pzwritep = uint32toa(uii, pzwritep);
 	append_binary_eoln(&pzwritep);
 	if (flex_pzwrite(&ps, &pzwritep)) {
 	  goto plink1_dosage_ret_WRITE_FAIL;


### PR DESCRIPTION
## Problem

`--dosage <file> occur` packs each distinct variant ID and its occurrence count into a fixed-stride buffer: the ID plus its null terminator, then a `uint32_t`. Because the ID length is arbitrary, that count field is not 4-byte aligned, and the write side already accounts for it:

```c
      max_occur_id_len += sizeof(int32_t) + 1; // null, uint32_t
...
	  bufptr2 = memcpya(&(bufptr[ulii * max_occur_id_len]), ll_ptr->ss, slen);
	  ulii++;
	  memcpy(bufptr2, &(ll_ptr->ct), sizeof(int32_t));
```

The write-out loop, however, reads it back through a `uint32_t*` cast:

```c
	pzwritep = uint32toa(*((uint32_t*)(&(bufptr2[slen + 1]))), pzwritep);
```

That is undefined behavior, and it would fault on a target that does not tolerate unaligned access. The asymmetry (memcpy on write, cast on read) looks like an oversight rather than a deliberate choice.

## Reproducer

Valid input, nothing malformed. Built with `-fsanitize=undefined`:

```
$ plink --fam d.fam --dosage d.dosage format=1 occur

plink_dosage.c:2287:23: runtime error: load of misaligned address 0x107000484487 for type 'uint32_t' (aka 'unsigned int'), which requires 4 byte alignment
    #0 plink1_dosage(...) plink_dosage.c:2287
    #1 main plink.c:13491
```

Found by an exhaustive modifier sweep over the `--dosage` subsystem (1410 invocations across all three formats); this is the only site it reported, and it fired on 73 of them.

## Fix

Read the field with `memcpy()`, mirroring the write. `uii` is unused from that point to the end of the function, so no new local is needed.

## Verification

- `.occur.dosage` output is byte-identical before and after.
- A 24-invocation regression across `format=1/2/3` with `occur`, `noheader`, `--freq`, `--score`, `--pheno`, `--covar` and `--write-dosage` shows no output change.
- After the patch the only remaining sanitizer reports on this command come from `plink_common.c`, which is the subject of #405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)