### PR TITLE
Fix heap overflow when a range file names a contig absent from the fileset

### DIFF
--- a/1.9/plink_set.c
+++ b/1.9/plink_set.c
@@ -2221,6 +2221,7 @@ int32_t load_range_list_sortpos(char* fname, uint32_t border_extend, uintptr_t s
   uintptr_t chrom_max_gene_ct = 0;
   uint32_t chrom_code_end = chrom_info_ptr->max_code + 1 + chrom_info_ptr->name_ct;
   uint32_t chrom_idx = 0;
+  uint32_t chrom_bounds_end;
   Make_set_range** gene_arr;
   Make_set_range* msr_tmp;
   uint64_t* range_sort_buf;
@@ -2248,7 +2249,22 @@ int32_t load_range_list_sortpos(char* fname, uint32_t border_extend, uintptr_t s
     goto load_range_list_sortpos_ret_1;
   }
   gene_names = *gene_names_ptr;
-  if (bigstack_alloc_ul(chrom_code_end + 1, chrom_bounds_ptr)) {
+  // load_range_list() gives ranges on a chromosome that isn't in the dataset
+  // the sentinel code 9999 (which is why it rejects 10000+ contigs), and the
+  // loop below walks chrom_bounds[] up to whatever code it decodes from the
+  // name prefix.  So the array has to cover the largest code actually
+  // present, not just the dataset's chromosomes; otherwise a --clump-range /
+  // --annotate ranges= / --gene-report file naming an absent contig writes
+  // several thousand entries past the end of the allocation.
+  chrom_bounds_end = chrom_code_end;
+  for (gene_idx = 0; gene_idx < gene_ct; gene_idx++) {
+    bufptr = &(gene_names[gene_idx * max_gene_id_len]);
+    uii = (((unsigned char)bufptr[0]) * 1000) + (((unsigned char)bufptr[1]) * 100) + (((unsigned char)bufptr[2]) * 10) + ((unsigned char)bufptr[3]) - 53313;
+    if (uii > chrom_bounds_end) {
+      chrom_bounds_end = uii;
+    }
+  }
+  if (bigstack_alloc_ul(chrom_bounds_end + 1, chrom_bounds_ptr)) {
     goto load_range_list_sortpos_ret_NOMEM;
   }
   chrom_bounds = *chrom_bounds_ptr;


### PR DESCRIPTION
## Problem

`load_range_list()` encodes each range's chromosome as a four-character prefix on the set ID, and gives ranges whose chromosome is not in the dataset the sentinel code **9999**:

```c
	  // quasi-bugfix (7 Oct 2017): forgot to check for this
	  if (cur_chrom_code > 9998) {
	    logerrprint("Error: This command does not support 10000+ contigs.\n");
	    goto load_range_list_ret_INVALID_FORMAT;
	  } else if (cur_chrom_code == -1) {
            cur_chrom_code = 9999;
          }
	  uitoa_z4((uint32_t)cur_chrom_code, ll_tmp->ss);
```

`load_range_list_sortpos()` decodes that prefix back into `uii` and treats it as an ordinary chromosome index:

```c
    uii = (((unsigned char)bufptr[0]) * 1000) + ... - 53313;
    if (chrom_idx < uii) {
      ...
      do {
	chrom_bounds[++chrom_idx] = gene_idx;
      } while (chrom_idx < uii);
    }
```

but `chrom_bounds` is allocated with only `chrom_code_end + 1` entries, where `chrom_code_end` counts the dataset's chromosomes. On a fileset with one chromosome that is 28 entries, so a single range line naming an absent contig writes `chrom_bounds[28 .. 9999]`, roughly 80 KB past the end.

Instrumented run, one such line in the range file:

```
[dbg] --clump-range: gene_ct=59 chrom_code_end=27 max_code=26 name_ct=0
[dbg] gene 0  encoded chrom idx 1    (chrom_code_end 27)
[dbg] gene 58 encoded chrom idx 9999 (chrom_code_end 27)
```

The write lands inside the bigstack workspace, which is one large allocation, so AddressSanitizer cannot see it. It surfaces later as a wild pointer.

## Reproducer

```
$ plink --bfile data --clump plink.assoc --clump-range genes.txt --allow-extra-chr
Segmentation fault
$ echo $?
139
```

```
#0 interval_in_setdef(setdef=0x000000000000003a, marker_idx_start=362, marker_idx_end=362) plink_set.c:125
#1 clump_reports(...) plink_ld.c:13819
#2 plink(...) plink.c:2144
```

`0x3a` is 58: the code read a `chrom_bounds` count as if it were a pointer.

Reproduced on the released b.7.11 binary and on current master. This is not an exotic input: a gene range list that covers scaffolds or contigs absent from the current fileset is ordinary, and `--allow-extra-chr` is exactly what keeps those lines instead of rejecting them.

## Fix

Size the array by the largest code actually present rather than by the dataset's chromosome count. `--annotate ranges=` and `--gene-report` use the same loader and were writing out of bounds too, though without a visible crash.

## Verification

- The three commands now exit 0 on the input that crashed.
- Output on well-formed input is byte-identical to master across 12 invocations: `--clump-range` (plain, `--clump-range-border`, `--clump-verbose`, `--clump-best`), `--annotate ranges=` (`block`, `minimal`, `distance`, `prune`), `--gene-report` (plain, `--pfilter`, `--gene-list-border`) and `--make-set`.

Found by a randomized fuzz of the report-based tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)