### PR TITLE
CalcKing(): don't mask past the end of variant_include[]

### DIFF
--- a/2.0/plink2_matrix_calc.cc
+++ b/2.0/plink2_matrix_calc.cc
@@ -1926,9 +1926,14 @@ PglErr CalcKing(const SampleIdInfo* siip, const uintptr_t* variant_include_orig,
           }
           parity = 1 - parity;
           if (variant_idx) {
-            uintptr_t* variant_include_update = &(variant_include[prev_read_block_idx * read_block_sizel]);
+            const uintptr_t update_word_offset = S_CAST(uintptr_t, prev_read_block_idx) * read_block_sizel;
+            uintptr_t* variant_include_update = &(variant_include[update_word_offset]);
+            // The last read block is normally partial, and variant_include[]
+            // is only raw_variant_ctl words long, so masking a full block's
+            // worth of words would run off the end of it.
+            const uintptr_t update_word_ct = MINV(read_block_sizel, raw_variant_ctl - update_word_offset);
             for (uint32_t tidx = 0; tidx != calc_thread_ct; ++tidx) {
-              BitvecInvmask(sparse_ctx.thread_sparse_excludes[parity][tidx], read_block_sizel, variant_include_update);
+              BitvecInvmask(sparse_ctx.thread_sparse_excludes[parity][tidx], update_word_ct, variant_include_update);
             }
             if (variant_idx == variant_ct) {
               break;


### PR DESCRIPTION
## Problem

`CalcKing()`'s sparse-variant pass removes each thread's excluded variants from `variant_include[]` one read block at a time:

```c
            uintptr_t* variant_include_update = &(variant_include[prev_read_block_idx * read_block_sizel]);
            for (uint32_t tidx = 0; tidx != calc_thread_ct; ++tidx) {
              BitvecInvmask(sparse_ctx.thread_sparse_excludes[parity][tidx], read_block_sizel, variant_include_update);
            }
```

`variant_include` is allocated with exactly `raw_variant_ctl` words:

```c
    if (unlikely(bigstack_alloc_w(raw_variant_ctl, &variant_include))) {
```

while `read_block_sizel` derives from `sparse_read_block_size`, which `PgenMtLoadInit()` sizes from available memory, not from the variant count. The last read block is normally partial, so masking a full block's worth of words runs off the end of the array.

It does not take an unusual fileset. With 40 variants and a 65536-variant read block there is one block, and it masks 1024 words into a 1-word array:

```
[dbg] BitvecInvmask: read_block_sizel=1024 (8192 bytes), target=0x107000025900
==44030==ERROR: AddressSanitizer: use-after-poison on address 0x107000025980
```

0x107000025980 is `target + 128`, i.e. the first byte past the block.

## Why this hasn't shown up

The write lands in the not-yet-claimed part of the bigstack workspace. Since the workspace is one large `malloc`, AddressSanitizer cannot see anything that stays inside it, and the overrun is silent.

I found it by building with a guard region poisoned (`__asan_poison_memory_region`) after every `bigstack_alloc()` block, which makes intra-workspace overruns visible. That instrumentation is a local audit change only, not part of this PR.

## Fix

Clamp the word count to the words that actually exist.

## Verification

The masked-off tail bits are beyond `raw_variant_ctl` and were never read, so results are unchanged:

- 25 invocations across `--make-king`, `--make-king-table` (plain and `cols=+kinship`), `--make-king square` and `--king-cutoff`, over five filesets including multiallelic and dosage data: byte-identical.
- A 3000-sample x 15000-variant fileset, spanning several read blocks: byte-identical.
- The guard-region report is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)