### PR TITLE
WriteGenoCounts(): pass a word count to BitvecXor3Copy()

### DIFF
--- a/2.0/plink2_misc.cc
+++ b/2.0/plink2_misc.cc
@@ -4434,7 +4434,7 @@ PglErr WriteGenoCounts(const uintptr_t* sample_include, const uintptr_t* sex_nm,
         if (unlikely(bigstack_alloc_w(raw_sample_ctl, &nonfemale_tmp))) {
           goto WriteGenoCounts_ret_NOMEM;
         }
-        BitvecXor3Copy(sample_include, sex_male, sex_nm, raw_sample_ct, nonfemale_tmp);
+        BitvecXor3Copy(sample_include, sex_male, sex_nm, raw_sample_ctl, nonfemale_tmp);
         sex_nonfemale = nonfemale_tmp;
       }
       FillCumulativePopcounts(sex_nonfemale, raw_sample_ctl, sex_nonfemale_cumulative_popcounts);


### PR DESCRIPTION
## Problem

`WriteGenoCounts()`'s chrY branch builds a "non-female" mask into a buffer sized in words, then passes a sample count as the length:

```c
        uintptr_t* nonfemale_tmp;
        if (unlikely(bigstack_alloc_w(raw_sample_ctl, &nonfemale_tmp))) {
          goto WriteGenoCounts_ret_NOMEM;
        }
        BitvecXor3Copy(sample_include, sex_male, sex_nm, raw_sample_ct, nonfemale_tmp);
```

`BitvecXor3Copy()`'s fourth parameter is `word_ct`, so this writes `raw_sample_ct` words into a `raw_sample_ctl`-word buffer, 64 times what was allocated. With 4000 samples that is about 31 KB past a 512-byte buffer.

Every other call site in the tree passes the word count, including the one in this same file:

```
plink2_data.cc:3037    BitvecXor3Copy(ctx.sample_include, ctx.sex_male, sex_nm, raw_sample_ctl, sex_nonfemale);
plink2_data.cc:11032   BitvecXor3Copy(sample_include, sex_male, sex_nm, raw_sample_ctl, y_include);
plink2_glm.cc:2513     BitvecXor3Copy(orig_sample_include, sex_male, sex_nm, raw_sample_ctl, sex_nonfemale_tmp);
plink2_misc.cc:4994    BitvecXor3Copy(sample_include, sex_male, sex_nm, raw_sample_ctl, nonfemale_tmp);
```

The branch is reached whenever chrY counts are being written and some samples have unknown sex.

## Why this hasn't shown up

The overrun lands in the not-yet-claimed part of the bigstack workspace. The workspace is one large `malloc`, so AddressSanitizer sees nothing, and no later allocation is clobbered because the write happens before them. It is a latent out-of-bounds write rather than an observed corruption: I could not make it change any output.

I found it by building with a guard region poisoned (`__asan_poison_memory_region`) after every `bigstack_alloc()` block, which makes intra-workspace overruns visible:

```
WRITE of size 16 at 0x107000026700
    #0 plink2::BitvecXor3Copy(...) plink2_cmdline.cc:1248
    #1 plink2::WriteGenoCounts(...) plink2_misc.cc:4437
```

That instrumentation is a local audit change only, not part of this PR.

## Verification

`--geno-counts` output is unchanged:

- 4000-sample fileset with chrY, chrX and autosomes, a third of the samples of unknown sex (which is what reaches this branch): identical.
- 60000-sample fileset at `--memory 640` and `--memory 1000`: identical.
- The guard-region report is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)