### PR TITLE
--flip-scan: drop two out-of-bounds stores into neg_uidx_buf

### DIFF
--- a/1.9/plink_ld.c
+++ b/1.9/plink_ld.c
@@ -1625,9 +1625,7 @@ int32_t flipscan(Ld_info* ldip, FILE* bedfile, uintptr_t bed_offset, uintptr_t m
   }
   ulii = (max_window_size + 1) * 2;
   for (uljj = 0; uljj < max_window_size; uljj++) {
-    neg_uidx_buf[uljj * ulii] = 0.0;
-    neg_uidx_buf[uljj * ulii + 1] = 0.0;
-    // bugfix: initialize r_matrix diagonal
+    // initialize r_matrix diagonal
     r_matrix[uljj * ulii] = 0.0;
     r_matrix[uljj * ulii + 1] = 0.0;
   }


### PR DESCRIPTION
## Problem

`flipscan()` initializes the `r_matrix` diagonal like this:

```c
  ulii = (max_window_size + 1) * 2;
  for (uljj = 0; uljj < max_window_size; uljj++) {
    neg_uidx_buf[uljj * ulii] = 0.0;
    neg_uidx_buf[uljj * ulii + 1] = 0.0;
    // bugfix: initialize r_matrix diagonal
    r_matrix[uljj * ulii] = 0.0;
    r_matrix[uljj * ulii + 1] = 0.0;
  }
```

The `r_matrix` stores are right: it holds `max_window_size * max_window_size * 2` doubles, and `uljj * ulii` walks its diagonal.

The same subscript applied to `neg_uidx_buf` is not. That buffer is

```c
  uint32_t* neg_uidx_buf;
...
      bigstack_alloc_ui(max_window_size, &neg_uidx_buf) ||
```

so it holds `max_window_size` uint32s, while the loop reaches index `(max_window_size - 1) * (max_window_size + 1) * 2 + 1`, roughly `2 * max_window_size^2`. With a 100-marker window that is about 80 KB written past a 400-byte buffer, straight over the allocations made right after it (`pheno_male_include2`, `missing_cts`, `window_geno`, `window_mask`, and `r_matrix` itself).

The two stores are also dead. `neg_uidx_buf` is a compact list: reset with `neg_r_ct = 0`, appended to as `neg_uidx_buf[neg_r_ct++] = window_uidxs[window_cidx3]`, and read back only for indices below `neg_r_ct`. It never needs pre-initialization. Assigning `0.0` to a `uint32_t` array is the other hint that these two lines were copied from the `r_matrix` pair below them; `git blame` puts them in the original 2014 implementation, with the `r_matrix` pair added in 2016.

## Why this hasn't shown up

The writes stay inside the bigstack workspace, which is one large `malloc`, so AddressSanitizer cannot see them. I found this by building with a guard region poisoned (`__asan_poison_memory_region`) after every `bigstack_alloc()` block; that instrumentation is a local audit change, not part of this PR.

## Fix

Delete the two lines.

## Verification

- Output is byte-identical: 20 invocations across `--flip-scan`, `verbose`, `--flip-scan-window`, `--flip-scan-window-kb` and `--flip-scan-threshold`, over four filesets.
- The guard-region report is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)