### PR TITLE
Unscramble2(): use a vector count, not a word count

### DIFF
--- a/2.0/plink2_misc.cc
+++ b/2.0/plink2_misc.cc
@@ -7280,7 +7280,7 @@ THREAD_FUNC_DECL SampleCountsThread(void* raw_arg) {
 }
 
 void Unscramble2(uint32_t sample_ct, uint32_t* dst, uint32_t* unscramble_buf) {
-  const uint32_t acc2_vec_ct = NypCtToWordCt(sample_ct);
+  const uint32_t acc2_vec_ct = NypCtToVecCt(sample_ct);
   memcpy(unscramble_buf, dst, acc2_vec_ct * 16 * kBytesPerVec);
   for (uint32_t sample_idx = 0; sample_idx != sample_ct; ++sample_idx) {
     const uint32_t scrambled_idx = VcountScramble2(sample_idx);


### PR DESCRIPTION
## Problem

`Unscramble2()` copies the 32-bit accumulator stage before permuting it back into sample order:

```c
void Unscramble2(uint32_t sample_ct, uint32_t* dst, uint32_t* unscramble_buf) {
  const uint32_t acc2_vec_ct = NypCtToWordCt(sample_ct);
  memcpy(unscramble_buf, dst, acc2_vec_ct * 16 * kBytesPerVec);
```

`acc2_vec_ct` is a vector count everywhere else, and every other site in this file computes it with `NypCtToVecCt()`:

```
plink2_misc.cc:6795   const uint32_t acc2_vec_ct = NypCtToVecCt(sample_ct);
plink2_misc.cc:7482   const uintptr_t acc2_vec_ct = NypCtToVecCt(sample_ct);
plink2_misc.cc:10288  const uint32_t acc2_vec_ct = NypCtToVecCt(sample_ct);
plink2_misc.cc:10828  const uintptr_t acc2_vec_ct = NypCtToVecCt(sample_ct);
```

including the one `unscramble_buf` is sized from:

```c
    const uintptr_t acc32_vec_ct = acc2_vec_ct * 16;
...
    if (unlikely(bigstack_alloc_u32(acc32_vec_ct * kInt32PerVec, &unscramble_buf))) {
```

`NypCtToWordCt()` is `kWordsPerVec` times larger than `NypCtToVecCt()`, so the `memcpy` is 2x too large on SSE builds, 4x on AVX2 and 8x on AVX-512. It writes past `unscramble_buf` and reads past `dst`.

## Why this hasn't shown up

The overrun stays inside the bigstack workspace, which is one large `malloc`, so AddressSanitizer sees nothing. I found it by building with a guard region poisoned (`__asan_poison_memory_region`) after every `bigstack_alloc()` block; that instrumentation is a local audit change, not part of this PR.

```
==...==ERROR: AddressSanitizer: use-after-poison
    #0 __asan_memcpy
    #1 plink2::Unscramble2(...) plink2_misc.cc:7284
```

Reported on `--sample-counts` for every fileset tried.

## Verification

The extra words were never read back (the permutation only touches indices below `sample_ct`), so results are unchanged:

- 20 `--sample-counts` invocations (plain, `zs`, `cols=+hom`, `cols=+het,+diploidts`) across five filesets including multiallelic and dosage data: byte-identical.
- A 3000-sample fileset: byte-identical.
- The guard-region report is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)