### PR TITLE
--annotate: don't write no_annot_str into a zero-length buffer

### DIFF
--- a/1.9/plink_set.c
+++ b/1.9/plink_set.c
@@ -2873,7 +2873,14 @@ int32_t annotate(const Annot_info* aip, uint32_t allow_extra_chroms, char* outna
   } else {
     // worst case: max_onevar_attr_ct attributes and chrom_max_range_ct range
     // annotations
-    if (bigstack_alloc_c((max_onevar_attr_ct * max_attr_id_len) + (chrom_max_range_ct * (max_range_name_len + (3 + 16 * (border != 0)) * range_dist)), &writebuf)) {
+    ulii = (max_onevar_attr_ct * max_attr_id_len) + (chrom_max_range_ct * (max_range_name_len + (3 + 16 * (border != 0)) * range_dist));
+    // A variant with no annotation writes no_annot_str instead, and the
+    // worst-case annotation width above is zero when no ranges or attributes
+    // were loaded at all (an empty or fully-filtered ranges= file).
+    if (ulii < strlen(no_annot_str)) {
+      ulii = strlen(no_annot_str);
+    }
+    if (bigstack_alloc_c(ulii, &writebuf)) {
       goto annotate_ret_NOMEM;
     }
   }


### PR DESCRIPTION
## Problem

`annotate()` sizes `writebuf` for the widest annotation a single variant can carry:

```c
    if (bigstack_alloc_c((max_onevar_attr_ct * max_attr_id_len) + (chrom_max_range_ct * (max_range_name_len + (3 + 16 * (border != 0)) * range_dist)), &writebuf)) {
```

Both terms are zero when no ranges and no attributes were loaded at all: an empty `ranges=` file, or one whose entries are all filtered out by `subset=`. The buffer is then zero bytes long, and a variant with no annotation still writes into it:

```c
	wptr = strcpya(wptr, no_annot_str);
```

one byte for `.`, two for `NA`, past the end.

## This corrupts output

The bytes land in the record buffer next to it, so every data row comes out with the marker glued to its front:

```
$ plink --annotate plink.assoc ranges=empty.txt NA
NA 1   null_0          1    D   0.4215    0.419    d      0.02565 ...

$ plink --annotate plink.assoc ranges=empty.txt
.  1   null_0          1    D   0.4215    0.419    d      0.02565 ...
```

Correct output starts the row with the CHR field:

```
   1   null_0          1    D   0.4215    0.419    d      0.02565 ...
```

Every data line is affected, and the columns no longer line up with the header. Reproduced on the released b.7.11 binary and on current master, four ways: an empty `ranges=` file and a `ranges=` file with a `subset=` that matches nothing, each with and without the `NA` modifier.

An empty or fully-filtered gene range list is an ordinary thing to end up with, and nothing warns about it.

## Fix

Floor the allocation at `strlen(no_annot_str)`.

## Verification

- 14 `--annotate` invocations across `ranges=`, `attrib=`, `block`, `NA`, `prune`, `minimal`, `distance` and `subset=` are byte-identical to master.
- The four affected cases now produce the documented column layout.

Found with a build that poisons a guard region (`__asan_poison_memory_region`) after each `bigstack_alloc()` block, which makes overruns inside the workspace visible to AddressSanitizer; the workspace is a single allocation, so it is otherwise invisible. That instrumentation is a local audit change, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)