### PR TITLE
Tests: stop feeding files into head through cat

### DIFF
--- a/2.0/Tests/TEST_EXTRACT_CHR/run_tests.sh
+++ b/2.0/Tests/TEST_EXTRACT_CHR/run_tests.sh
@@ -4,9 +4,9 @@ set -exo pipefail
 
 plink --simulate simulate.txt --out tmp_data
 
-cat tmp_data.bim | head -n 147 > tmp_data1.bim
+head -n 147 tmp_data.bim > tmp_data1.bim
 cat tmp_data.bim | tail -n 150 | sed 's/^1/2/g' > tmp_data24.bim
-cat tmp_data24.bim | head -n 100 > tmp_data2.bim
+head -n 100 tmp_data24.bim > tmp_data2.bim
 cat tmp_data24.bim | tail -n 50 | sed 's/^2/4/g' > tmp_data4.bim
 
 cat tmp_data1.bim tmp_data2.bim tmp_data4.bim > tmp_data.bim

--- a/2.0/Tests/TEST_PHASED_VCF/run_tests.sh
+++ b/2.0/Tests/TEST_PHASED_VCF/run_tests.sh
@@ -36,8 +36,8 @@ diff -q 1kg_noheader.txt plink2_noheader.txt
 # sample 667
 cat 1kg_noheader.txt | cut -f 1-500,579-675,677- > 1kg_noheader_pruned.txt
 
-cat plink1_data.fam | head -n 569 | tail -n 78 | cut -f 1-2 > remove.txt
-cat plink1_data.fam | head -n 667 | tail -n 1 | cut -f 1-2 >> remove.txt
+head -n 569 plink1_data.fam | tail -n 78 | cut -f 1-2 > remove.txt
+head -n 667 plink1_data.fam | tail -n 1 | cut -f 1-2 >> remove.txt
 $1/plink2 $2 $3 --pfile plink2_data --remove remove.txt --export vcf --out plink2_pruned
 
 # there's a tiny chance that fileDate will change between this and the next VCF

--- a/2.0/Tests/TEST_PMERGE/run_tests.sh
+++ b/2.0/Tests/TEST_PMERGE/run_tests.sh
@@ -13,7 +13,7 @@ set -exo pipefail
 plink --simulate simulate.txt --simulate-missing 0.02 --out tmp_data
 
 # Three chromosomes, so the parts have disjoint coordinate ranges.
-cat tmp_data.bim | head -n 99 > tmp_data1.bim
+head -n 99 tmp_data.bim > tmp_data1.bim
 cat tmp_data.bim | sed -n '100,198p' | sed 's/^1/2/' > tmp_data2.bim
 cat tmp_data.bim | tail -n 99 | sed 's/^1/3/' > tmp_data3.bim
 cat tmp_data1.bim tmp_data2.bim tmp_data3.bim > tmp_data.bim


### PR DESCRIPTION
## Problem

`2.0/Tests/run_tests.sh` runs with `set -exo pipefail`, and five pipelines in the per-test scripts have the form

```sh
cat plink1_data.fam | head -n 667 | tail -n 1 | cut -f 1-2 >> remove.txt
```

`head` exits as soon as it has its lines, `cat` gets SIGPIPE, and `pipefail` turns that into a failed pipeline. Whether it fires depends on whether `cat` finishes writing before `head` leaves, so it surfaces as an intermittent CI failure, most often on macOS:

```
+ cat plink1_data.fam
+ head -n 667
+ tail -n 1
+ cut -f 1-2
cat: stdout: Broken pipe
##[error]Process completed with exit code 1.
```

It is a genuine race rather than a fluke. With a large enough input the old form fails every time:

```
cat file | head -n N : 200/200 failed    (set -eo pipefail)
head -n N file       : 0/200 failed
```

The five sites:

```
2.0/Tests/TEST_PMERGE/run_tests.sh:16
2.0/Tests/TEST_PHASED_VCF/run_tests.sh:39
2.0/Tests/TEST_PHASED_VCF/run_tests.sh:40
2.0/Tests/TEST_EXTRACT_CHR/run_tests.sh:7
2.0/Tests/TEST_EXTRACT_CHR/run_tests.sh:9
```

## Fix

Give `head` the filename directly, so nothing upstream can be killed by its early exit. The commands are otherwise unchanged.

## Verification

`2.0/Tests/run_tests.sh` passes in full with the rewritten scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)