### PR TITLE
Terminate two --help parameter lists

### DIFF
--- a/2.0/plink2_help.cc
+++ b/2.0/plink2_help.cc
@@ -2728,7 +2728,7 @@ PglErr DispHelp(const char* const* argvk, uint32_t param_ct) {
 "                         founders to estimate from.  Use --bad-ld to force\n"
 "                         PLINK 2 to proceed.\n"
               );
-    HelpPrint("export-allele\0recode-allele\0export\0recode", &help_ctrl, 0,
+    HelpPrint("export-allele\0recode-allele\0export\0recode\0", &help_ctrl, 0,
 "  --export-allele <file> : With --export A/AD/Av, count alleles named in the\n"
 "                           file, instead of REF alleles.\n"
               );
@@ -3320,7 +3320,7 @@ PglErr DispHelp(const char* const* argvk, uint32_t param_ct) {
     HelpPrint("threads\0num_threads\0thread-num\0seed\0", &help_ctrl, 0,
 "  --threads <val>    : Set maximum number of compute threads.\n"
                );
-    HelpPrint("d\0covar-name\0exclude-snps\0pheno-name\0snps", &help_ctrl, 0,
+    HelpPrint("d\0covar-name\0exclude-snps\0pheno-name\0snps\0", &help_ctrl, 0,
 "  --d <char>         : Change variant/covariate range delimiter (normally '-').\n"
               );
     HelpPrint("seed\0", &help_ctrl, 0,


### PR DESCRIPTION
## Problem

`HelpPrint()` walks its first argument as a `\0`-delimited list, stopping on an empty entry:

```c
    while (*params_iter) {
      cur_param_starts[cur_param_ct] = params_iter;
      const uint32_t cur_slen = strlen(params_iter);
      cur_param_slens[cur_param_ct++] = cur_slen;
      params_iter = &(params_iter[cur_slen + 1]);
    }
```

Two call sites leave off the final `\0`:

```c
    HelpPrint("export-allele\0recode-allele\0export\0recode", &help_ctrl, 0,
    HelpPrint("d\0covar-name\0exclude-snps\0pheno-name\0snps", &help_ctrl, 0,
```

Both literals are 42 bytes including the implicit terminator, and the walk lands on index 42:

```
==49493==ERROR: AddressSanitizer: global-buffer-overflow
READ of size 1 at 0x000103208e0a
    #0 plink2::HelpPrint(...) plink2_cmdline.cc:2542
    #1 plink2::DispHelp(...) plink2_help.cc:2731
0x000103208e0a is located 0 bytes after global variable '.str.301' defined in '../plink2_help.cc' of size 42
```

## It is visible in the output

The bytes past the literal become extra entries in the list, so unrelated help text gets printed:

```
$ plink2 --help seed
...
--d <char>         : Change variant/covariate range delimiter (normally '-').

$ plink2 --help output-chr
--export-allele <file> : With --export A/AD/Av, count alleles named in the
                         file, instead of REF alleles.

$ plink2 --help rename-chrs
--export-allele <file> : ...
```

`--d` has nothing to do with `--seed`, and `--export-allele` nothing to do with `--output-chr` or `--rename-chrs`.

`cur_param_starts[]` and `cur_param_slens[]` are 64-entry stack arrays and the loop has no bound check, so a longer run of adjacent strings would overrun those too.

## Fix

Add the two missing terminators.

## Verification

- The three commands above now print only their own entries; the legitimate entries are all still there.
- `--help` output is byte-identical to master for all 408 flags apart from those three, and bare `--help` is unchanged.
- `2.0/Tests/run_tests.sh` passes.

The remaining AddressSanitizer report on `--help <flag>` is `Rawmemchr()` scanning the help payload a vector at a time, which is the usual aligned-scan idiom rather than a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)