### PR TITLE
Give CalcKingTableSubset()'s thread context function scope

### DIFF
--- a/2.0/plink2_matrix_calc.cc
+++ b/2.0/plink2_matrix_calc.cc
@@ -3531,6 +3531,10 @@ PglErr CalcKingTableSubset(const uintptr_t* orig_sample_include, const PedigreeI
   TextStream txs;
   CompressStreamState css;
   ThreadGroup tg;
+  // Function scope for the same reason as CalcKing()'s contexts: the workers
+  // hold a pointer to this, CleanupThreads() at the exit label is what joins
+  // them, and the PgrGet() error path inside the block jumps straight there.
+  CalcKingTableSubsetCtx ctx;
   PreinitTextStream(&txs);
   PreinitCstream(&css);
   PreinitThreads(&tg);
@@ -3595,7 +3599,6 @@ PglErr CalcKingTableSubset(const uintptr_t* orig_sample_include, const PedigreeI
     uintptr_t* splitbuf_ref2het;
     VecW* vecaligned_buf;
     // ok if allocations are a bit oversized
-    CalcKingTableSubsetCtx ctx;
     if (unlikely(bigstack_alloc_w(raw_sample_ctl, &cur_sample_include) ||
                  bigstack_alloc_u32(raw_sample_ctl, &sample_include_cumulative_popcounts) ||
                  bigstack_alloc_w(sample_ctaw2, &loadbuf) ||


### PR DESCRIPTION
Follow-up to #409, which gave `CalcKing()`'s contexts function scope. `CalcKingTableSubset()` in the same file has the identical structure: `ctx` inside the block, `SetThreadFuncAndData(..., &ctx, &tg)`, and `CleanupThreads(&tg)` at an exit label outside the block. Its `PgrGet()` failure path runs before that iteration's `JoinThreads()`, so it can jump out while workers from the previous iteration are still dereferencing `&ctx`.

**I could not get it to fire.** Under the same ASan build and the same inputs that reproduce the `CalcKing()` report at every truncation point:

```
--make-king (fixed by #409)           : stack-use-after-scope 4/4 truncations
--make-king-table --king-table-subset : 0/4 truncations, 0/21 byte corruptions
```

So this is defense against a window that exists structurally rather than a fix for an observed report. It moves two lines and makes the two functions consistent; close it if you would rather not carry an unreproduced change.

No output change: eight files across six KING command forms (`--make-king-table`, with `--king-table-subset`, `rel-check`, `zs`, `--make-king`, `--make-king square`) compare byte-identical against a build of current master, and `2.0/Tests` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)