### PR TITLE
1.9: accept -v/-V as --version

### DIFF
--- a/1.9/plink.c
+++ b/1.9/plink.c
@@ -3595,7 +3595,8 @@ int32_t main(int32_t argc, char** argv) {
 	fputs(notestr_null_calc2, stdout);
 	goto main_ret_1;
       }
-      if (!strcmp("version", argptr)) {
+      // -v/-V as well as --version, mirroring the -h/-? handling just above.
+      if ((!strcmp("version", argptr)) || (!strcmp("v", argptr)) || (!strcmp("V", argptr))) {
 	ujj = 1;
       } else if ((!strcmp("silent", argptr)) || (!strcmp("gplink", argptr))) {
 	ukk = 1;


### PR DESCRIPTION
`-h` and `-?` are already accepted as short forms of `--help`, but `--version` has no short form, so `-v` and `-V` fall through to the generic unrecognized-flag path:

```
$ plink -v
PLINK v1.9.0-b.7.11 64-bit (19 Aug 2025)           cog-genomics.org/plink/1.9/
(C) 2005-2025 Shaun Purcell, Christopher Chang   GNU General Public License v3
Logging to plink.log.
Options in effect:
  --v

Error: Unrecognized flag ('--v').
```

Two things make this read badly. The version banner prints before the error, so it looks like the run half-succeeded; and a typo leaves a `plink.log` behind, which `--version` itself does not. Both follow from the flag being unrecognized rather than from anything specific to `-v`, so accepting it fixes both at once: `--version` is handled before the log is opened.

After:

```
$ plink -v
PLINK v1.9.1-dev 64-bit (9 Sep 2026)
```

`-v`, `--v`, `-V` and `--V` all work, matching how `-h` and `--h` both reach the help path today (the leading dashes are stripped before the comparison).

No flag named `v` or `V` exists in 1.9, so nothing is shadowed, and `--vcf`, `--vif` and the rest still parse.

There is a companion PR for 2.0, which has the same asymmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)