### PR TITLE
2.0: accept -v/-V as --version

### DIFF
--- a/2.0/plink2_cmdline.cc
+++ b/2.0/plink2_cmdline.cc
@@ -3247,7 +3247,10 @@ PglErr CmdlineParsePhase1(const char* ver_str, const char* ver_str2, const char*
           reterr = kPglRetHelp;
           goto CmdlineParsePhase1_ret_1;
         }
-        if (strequal_k(flagname_p, "version", flagname_p_slen)) {
+        // -v/-V as well as --version, mirroring the -h/-? handling above.
+        if (strequal_k(flagname_p, "version", flagname_p_slen) ||
+            strequal_k(flagname_p, "v", flagname_p_slen) ||
+            strequal_k(flagname_p, "V", flagname_p_slen)) {
           version_present = 1;
         } else if (strequal_k(flagname_p, "silent", flagname_p_slen)) {
           silent_present = 1;


### PR DESCRIPTION
Same asymmetry as the companion 1.9 PR: `-h` and `-?` are accepted as short forms of `--help`, but `--version` has no short form, so `-v` and `-V` fall through to the unrecognized-flag path:

```
$ plink2 -v
PLINK v2.0.0-b.1 M1 (9 Sep 2026)                    cog-genomics.org/plink/2.0/
(C) 2005-2026 S Purcell, C Chang, B Demaille      GNU General Public License v3
Logging to plink2.log.
Options in effect:
  --v

Error: Unrecognized flag ('--v').
```

The banner before the error makes it look like the run half-succeeded, and a typo leaves a `plink2.log` behind. `--version` is handled before the log is opened, so accepting `-v`/`-V` fixes that too.

After:

```
$ plink2 -v
PLINK v2.0.0-b.1 M1 (9 Sep 2026)
```

No flag named `v` or `V` exists, so nothing is shadowed; `--vcf`, `--validate`, `--variant-score` and the rest still parse, and `2.0/Tests` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)