### PR TITLE
Update four stale copyright end-years to 2026

### DIFF
--- a/2.0/cuda/plink2_matrix_cuda.h
+++ b/2.0/cuda/plink2_matrix_cuda.h
@@ -1,7 +1,7 @@
 #ifndef __PLINK2_MATRIX_CUDA_H__
 #define __PLINK2_MATRIX_CUDA_H__
 
-// This file is part of PLINK 2.00, copyright (C) 2005-2020 Shaun Purcell,
+// This file is part of PLINK 2.00, copyright (C) 2005-2026 Shaun Purcell,
 // Christopher Chang.
 //
 // This program is free software: you can redistribute it and/or modify it

--- a/2.0/include/pgenlib_ffi_support.cc
+++ b/2.0/include/pgenlib_ffi_support.cc
@@ -1,4 +1,4 @@
-// This library is part of PLINK 2.0, copyright (C) 2005-2022 Shaun Purcell,
+// This library is part of PLINK 2.0, copyright (C) 2005-2026 Shaun Purcell,
 // Christopher Chang, Benjamin Demaille.
 //
 // This library is free software: you can redistribute it and/or modify it

--- a/2.0/include/plink2_bits.cc
+++ b/2.0/include/plink2_bits.cc
@@ -1,4 +1,4 @@
-// This library is part of PLINK 2, copyright (C) 2005-2024 Shaun Purcell,
+// This library is part of PLINK 2, copyright (C) 2005-2026 Shaun Purcell,
 // Christopher Chang, Benjamin Demaille.
 //
 // This library is free software: you can redistribute it and/or modify it

--- a/2.0/plink2_matrix.cc
+++ b/2.0/plink2_matrix.cc
@@ -1,4 +1,4 @@
-// This file is part of PLINK 2.0, copyright (C) 2005-2022 Shaun Purcell,
+// This file is part of PLINK 2.0, copyright (C) 2005-2026 Shaun Purcell,
 // Christopher Chang, Benjamin Demaille.
 //
 // This program is free software: you can redistribute it and/or modify it


### PR DESCRIPTION
135 PLINK-owned source files already carry `2005-2026`. Four were missed by the last bulk update:

| file | was |
| --- | --- |
| `2.0/plink2_matrix.cc` | 2005-2022 |
| `2.0/include/pgenlib_ffi_support.cc` | 2005-2022 |
| `2.0/include/plink2_bits.cc` | 2005-2024 |
| `2.0/cuda/plink2_matrix_cuda.h` | 2005-2020 |

Comment-only; `2.0/Tests` passes.

Left alone deliberately, since they are not ours to bump or are not copyright years at all: the htslib files in `1.9/` (`hfile*`, `hts*`, `bgzf*`) are Genome Research Ltd's, the `LICENSE` files carry the GPL's own 2007 date, `2.0/include/LICENSE.QD` is the QD library's, and the `Date:` fields in the R package `DESCRIPTION` files are release dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)