### PR TITLE
1.9: optional SYSTEM_HTSLIB build against an installed htslib

### DIFF
--- a/1.9/Makefile
+++ b/1.9/Makefile
@@ -2,10 +2,19 @@
 #
 # Compilation options:
 #   Do not link to LAPACK                    NO_LAPACK
+#   Link against the system htslib           SYSTEM_HTSLIB
+#     instead of the bundled bgzf.c/hfile.c
 
 # Leave blank after "=" to disable; put "= 1" to enable
 # (when enabled, "#define NOLAPACK" must be uncommented in plink_common.h)
 NO_LAPACK =
+
+# Leave blank after "=" to build the bundled copies of htslib's bgzf.c and
+# hfile.c, which is the default and keeps the build self-contained; put "= 1"
+# to compile against an installed htslib instead, so that it tracks that
+# library's updates.  Only bgzf_open/write/mt/close are used, all of which have
+# been stable across htslib releases.
+SYSTEM_HTSLIB =
 
 # Variable that allows additional linker flags (e.g., "-L/path/to/libs") to be
 # passed into the linker; to use this, invoke 'make LDFLAGS_EXTRA="<opts>"'.
@@ -76,7 +85,19 @@ ifdef NO_LAPACK
   BLASFLAGS=
 endif
 
-OBJS = plink.o plink_assoc.o plink_calc.o plink_cluster.o plink_cnv.o plink_common.o plink_data.o plink_dosage.o plink_family.o plink_filter.o plink_glm.o plink_help.o plink_homozyg.o plink_lasso.o plink_ld.o plink_matrix.o plink_misc.o plink_perm.o plink_rserve.o plink_set.o plink_stats.o SFMT.o dcdflib.o pigz.o yarn.o Rconnection.o hfile.o bgzf.o
+OBJS = plink.o plink_assoc.o plink_calc.o plink_cluster.o plink_cnv.o plink_common.o plink_data.o plink_dosage.o plink_family.o plink_filter.o plink_glm.o plink_help.o plink_homozyg.o plink_lasso.o plink_ld.o plink_matrix.o plink_misc.o plink_perm.o plink_rserve.o plink_set.o plink_stats.o SFMT.o dcdflib.o pigz.o yarn.o Rconnection.o
+HTSLIB_OBJS = hfile.o bgzf.o
+
+ifdef SYSTEM_HTSLIB
+  HTSLIB_OBJS =
+  HTSLIB_CFLAGS ?= $(shell pkg-config --cflags htslib 2>/dev/null)
+  HTSLIB_LDFLAGS ?= $(shell pkg-config --libs htslib 2>/dev/null || echo -lhts)
+  CFLAGS +=	-DSYSTEM_HTSLIB $(HTSLIB_CFLAGS)
+  CXXFLAGS +=	-DSYSTEM_HTSLIB $(HTSLIB_CFLAGS)
+  LDFLAGS +=	$(HTSLIB_LDFLAGS)
+endif
+
+OBJS +=	$(HTSLIB_OBJS)
 
 # In the event that you are still concurrently using PLINK 1.07, we suggest
 # renaming that binary to "plink107", and this one to "plink" or "plink1".

--- a/1.9/plink_data.c
+++ b/1.9/plink_data.c
@@ -25,8 +25,13 @@
 #endif
 
 #include "SFMT.h"
-#include "bgzf.h"
-#include "hts.h"
+#ifdef SYSTEM_HTSLIB
+#  include <htslib/bgzf.h>
+#  include <htslib/hts.h>
+#else
+#  include "bgzf.h"
+#  include "hts.h"
+#endif
 #include "pigz.h"
 #include "plink_common.h"
 #include "plink_family.h"


### PR DESCRIPTION
1.9 bundles htslib's `bgzf.c` and `hfile.c`, so the bgzf writer behind `--recode vcf bgz` is frozen at whatever htslib revision was copied in. Distribution packagers normally prefer to link the system copy so that it tracks that library's fixes.

`make SYSTEM_HTSLIB=1` now drops the two bundled objects, adds `-DSYSTEM_HTSLIB`, and takes its flags from `pkg-config` (falling back to `-lhts`):

```
$ make SYSTEM_HTSLIB=1
c++ -c ... -DSYSTEM_HTSLIB -I/opt/homebrew/Cellar/htslib/1.24/include ... plink_data.c -o plink_data.o
c++ plink.o ... Rconnection.o   -framework Accelerate -ldl -L/opt/homebrew/Cellar/htslib/1.24/lib -lhts -lz -o plink
```

**The default is unchanged and still self-contained.** That is deliberate rather than conservatism: the bundled `hfile.c` is the copy carrying the `plink_common.h` include for `HANDLE`, which the Windows build needs, and a hard htslib dependency would make plink harder to build for the people it is easiest for today.

Only `bgzf_open`, `bgzf_write`, `bgzf_mt` and `bgzf_close` are used, and their signatures have been stable across htslib releases, so the shim is a conditional include in `plink_data.c` rather than an abstraction layer:

```c
#ifdef SYSTEM_HTSLIB
#  include <htslib/bgzf.h>
#  include <htslib/hts.h>
#else
#  include "bgzf.h"
#  include "hts.h"
#endif
```

### Testing, against htslib 1.24

* Both modes build from a clean tree with no warnings.
* The system build links `libhts.3.dylib` and omits `bgzf.o`/`hfile.o`; the default build links neither and still compiles both.
* `--recode vcf bgz` output is valid BGZF under `htsfile` in both, and the decompressed content is byte-identical between the two builds. The compressed sizes differ (215088 vs 218142 bytes), which is just htslib 1.24's deflate settings against the bundled copy's.

Note for context: this does not affect 2.0, which uses its own bgzf implementation and no htslib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)