### PR TITLE
CI: stop can_install_pgenlib_package tripping over third-party apt sources

### DIFF
--- a/.github/workflows/can_install_pgenlib_package.yaml
+++ b/.github/workflows/can_install_pgenlib_package.yaml
@@ -23,6 +23,16 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
 
+      # The runner image carries third-party apt sources that this job has no
+      # use for.  setup-r runs apt-get update, which scans all of them, so an
+      # inconsistent index on any one of them fails the job for reasons that
+      # have nothing to do with plink-ng.  Dropping the Google Chrome source
+      # is enough: it is the one that has broken here.
+      - name: Drop apt sources this job does not need
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/*google*.list \
+                     /etc/apt/sources.list.d/*google*.sources
+
       # Install R
       - uses: r-lib/actions/setup-r@v2
 


### PR DESCRIPTION
`r-lib/actions/setup-r@v2` runs `apt-get update`, which scans every source configured on the runner image, including Google Chrome's. When that repository serves an index whose hash does not match its `Release` file, apt exits non-zero, setup-r fails to install R, and the job fails for reasons that have nothing to do with this repository:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
   Release file created at: Wed, 09 Sep 2026 17:16:59 +0000
E: Some index files failed to download. They have been ignored, or old ones used instead.
##[error]Failed to get R release: Failed to get R 4.6.1: Failed to install R: Error: The process '/usr/bin/sudo' failed with exit code 100
```

This started today at roughly 17:25 UTC. Every run of this workflow before then passed and both runs after it failed, on a branch whose only content is two files under `.github/`:

```
17:37 failure can_install_pgenlib_package
17:35 failure can_install_pgenlib_package
17:24 success can_install_pgenlib_package
17:20 success can_install_pgenlib_package
17:10 success can_install_pgenlib_package
```

The job installs R and `libcurl4-openssl-dev`, so it has no use for the Chrome repository. Removing that source before setup-r keeps an outage there from taking the job down. Both the `.list` and the deb822 `.sources` spelling are covered, since the runner images have been migrating between them.

This should be self-demonstrating: if Google's index is still inconsistent when this runs, this PR's own check passing while #435's continues to fail is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)