### PR TITLE
2.0: port --make-perm-pheno

### DIFF
--- a/2.0/Tests/TEST_MAKE_PERM_PHENO/.gitignore
+++ b/2.0/Tests/TEST_MAKE_PERM_PHENO/.gitignore
@@ -1,0 +1,4 @@
+plink19*
+plink2*
+tmp_*
+*.log

--- a/2.0/Tests/TEST_MAKE_PERM_PHENO/check_pphe.py
+++ b/2.0/Tests/TEST_MAKE_PERM_PHENO/check_pphe.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Check a .pphe against the phenotype it was permuted from.
+
+A permutation report cannot be compared value-by-value against PLINK 1.9, since
+the two draw from different random streams.  What must hold is that every
+column is a rearrangement of the same values, that missing stays missing, and
+that the columns actually differ from each other.
+"""
+import sys
+from collections import Counter
+
+
+def main():
+    pheno_path, pphe_path = sys.argv[1], sys.argv[2]
+    base = {}
+    with open(pheno_path) as f:
+        for line in f:
+            if line.startswith('#'):
+                continue
+            g = line.split()
+            base[g[1]] = g[2]
+    rows = [line.rstrip('\n').split('\t') for line in open(pphe_path)]
+    hdr, body = rows[0], rows[1:]
+    perm_ct = sum(1 for h in hdr if h.startswith('PERM'))
+    assert perm_ct, 'no PERM columns'
+    id_col = hdr.index('IID')
+    first = id_col + 1
+
+    def norm(v):
+        try:
+            return '%.6g' % float(v)
+        except ValueError:
+            return v
+
+    orig = Counter(norm(v) for v in base.values() if v != 'NA')
+    assert orig, 'no nonmissing phenotype values'
+    for k in range(perm_ct):
+        col = Counter(norm(r[first + k]) for r in body if base[r[id_col]] != 'NA')
+        assert col == orig, 'column %d is not a rearrangement of the input' % (k + 1)
+    for r in body:
+        if base[r[id_col]] == 'NA':
+            for k in range(perm_ct):
+                assert r[first + k] == 'NA', 'sample %s gained a phenotype' % r[id_col]
+    cols = [tuple(r[first + k] for r in body) for k in range(perm_ct)]
+    assert len(set(cols)) == perm_ct, 'only %d of %d columns are distinct' % (len(set(cols)), perm_ct)
+    print('%d rows x %d permutations verified' % (len(body), perm_ct))
+
+
+if __name__ == '__main__':
+    main()

--- a/2.0/Tests/TEST_MAKE_PERM_PHENO/run_tests.sh
+++ b/2.0/Tests/TEST_MAKE_PERM_PHENO/run_tests.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# --make-perm-pheno.  The values cannot be compared against PLINK 1.9, which
+# draws from a different random stream, so the invariants are checked instead.
+
+set -exo pipefail
+
+plink --simulate simulate.txt --make-bed --out tmp_data > /dev/null
+
+# Case/control, with some phenotypes missing.
+awk 'BEGIN { print "#FID\tIID\tCC" }
+{ printf "%s\t%s\t%s\n", $1, $2, (NR % 10 == 0)? "NA" : ((NR % 2) + 1) }' tmp_data.fam > tmp_cc.txt
+$1/plink2 $2 $3 --bfile tmp_data --no-psam-pheno --pheno tmp_cc.txt --make-perm-pheno 8 --seed 1 --out plink2_cc
+python3 check_pphe.py tmp_cc.txt plink2_cc.pphe
+
+# Quantitative.
+awk 'BEGIN { print "#FID\tIID\tQT" } { printf "%s\t%s\t%.4f\n", $1, $2, NR * 0.37 }' tmp_data.fam > tmp_qt.txt
+$1/plink2 $2 $3 --bfile tmp_data --no-psam-pheno --pheno tmp_qt.txt --make-perm-pheno 5 --seed 1 --out plink2_qt
+python3 check_pphe.py tmp_qt.txt plink2_qt.pphe
+
+# --seed makes it reproducible, and a different seed gives something else.
+$1/plink2 $2 $3 --bfile tmp_data --no-psam-pheno --pheno tmp_cc.txt --make-perm-pheno 8 --seed 1 --out plink2_again
+diff -q plink2_cc.pphe plink2_again.pphe
+$1/plink2 $2 $3 --bfile tmp_data --no-psam-pheno --pheno tmp_cc.txt --make-perm-pheno 8 --seed 2 --out plink2_seed2
+if diff -q plink2_cc.pphe plink2_seed2.pphe > /dev/null; then
+    echo "two different seeds produced identical permutations"
+    exit 1
+fi
+
+# Zstd output round-trips.
+$1/plink2 $2 $3 --bfile tmp_data --no-psam-pheno --pheno tmp_cc.txt --make-perm-pheno 8 zs --seed 1 --out plink2_zs
+$1/plink2 $2 $3 --zst-decompress plink2_zs.pphe.zst > plink2_zs.pphe
+diff -q plink2_zs.pphe plink2_cc.pphe
+
+# Naming the phenotype is required when more than one is loaded.
+awk 'BEGIN { print "#FID\tIID\tA\tB" } { printf "%s\t%s\t1\t%.3f\n", $1, $2, NR * 0.11 }' tmp_data.fam > tmp_two.txt
+if $1/plink2 $2 $3 --bfile tmp_data --no-psam-pheno --pheno tmp_two.txt --make-perm-pheno 3 --out plink2_bad 2> tmp_err.txt; then
+    echo "expected --make-perm-pheno to require a phenotype name"
+    exit 1
+fi
+grep -q "name the one" tmp_err.txt
+$1/plink2 $2 $3 --bfile tmp_data --no-psam-pheno --pheno tmp_two.txt --make-perm-pheno 3 B --seed 1 --out plink2_named
+# check_pphe wants a two-column phenotype file; build one holding just B.
+awk '{ printf "%s\t%s\t%s\n", $1, $2, $4 }' tmp_two.txt > tmp_b.txt
+python3 check_pphe.py tmp_b.txt plink2_named.pphe

--- a/2.0/Tests/TEST_MAKE_PERM_PHENO/simulate.txt
+++ b/2.0/Tests/TEST_MAKE_PERM_PHENO/simulate.txt
@@ -1,0 +1,3 @@
+99 low_maf_snps 0.01 0.05 0.5 0.25
+99 med_maf_snps 0.05 0.1 0.5 0.25
+99 high_maf_snps 0.1 0.4 0.5 0.25

--- a/2.0/Tests/run_tests.sh
+++ b/2.0/Tests/run_tests.sh
@@ -123,4 +123,9 @@ cd TEST_PGEN_MALFORMED
 cd ..
 echo "TEST_PGEN_MALFORMED passed."
 
+cd TEST_MAKE_PERM_PHENO
+./run_tests.sh $d $2 $3 > TEST_MAKE_PERM_PHENO.log
+cd ..
+echo "TEST_MAKE_PERM_PHENO passed."
+
 echo "All tests passed."

--- a/2.0/plink2.cc
+++ b/2.0/plink2.cc
@@ -201,6 +201,7 @@ ENUM_U31_DEF_START()
   kCmd1BitKingCutoff,
   kCmd1BitMissingReport,
   kCmd1BitWriteSnplist,
+  kCmd1BitMakePermPheno,
   kCmd1BitAlleleFreq,
   kCmd1BitGenoCounts,
   kCmd1BitHardy,
@@ -246,6 +247,7 @@ FLAGSET64_DEF_START()
   kfCommand1KingCutoff = (1LLU << kCmd1BitKingCutoff),
   kfCommand1MissingReport = (1LLU << kCmd1BitMissingReport),
   kfCommand1WriteSnplist = (1LLU << kCmd1BitWriteSnplist),
+  kfCommand1MakePermPheno = (1LLU << kCmd1BitMakePermPheno),
   kfCommand1AlleleFreq = (1LLU << kCmd1BitAlleleFreq),
   kfCommand1GenoCounts = (1LLU << kCmd1BitGenoCounts),
   kfCommand1Hardy = (1LLU << kCmd1BitHardy),
@@ -635,6 +637,8 @@ typedef struct Plink2CmdlineStruct {
   TwentythreeInfo twenty_three_info;
   TwoColParams* update_map_flag;
   TwoColParams* update_name_flag;
+  char* perm_pheno_name;
+  uint32_t perm_pheno_ct;
 } Plink2Cmdline;
 
 // er, probably time to just always initialize this...
@@ -2815,6 +2819,13 @@ PglErr Plink2Core(const Plink2Cmdline* pcp, MakePlink2Flags make_plink2_flags, c
         }
       }
 
+      if (pcp->command_flags1 & kfCommand1MakePermPheno) {
+        reterr = MakePermPheno(sample_include, &pii.sii, pheno_cols, pheno_names, pcp->perm_pheno_name, pcp->output_missing_pheno, raw_sample_ct, sample_ct, pheno_ct, max_pheno_name_blen, pcp->perm_pheno_ct, (pcp->misc_flags / kfMiscMakePermPhenoZs) & 1, pcp->max_thread_ct, sfmtp, outname, outname_end);
+        if (unlikely(reterr)) {
+          goto Plink2Core_ret_1;
+        }
+      }
+
       if (pcp->command_flags1 & kfCommand1WriteSnplist) {
         reterr = WriteSnplist(variant_include, variant_ids, variant_ct, (pcp->misc_flags / kfMiscWriteSnplistZs) & 1, (pcp->misc_flags / kfMiscWriteSnplistAllowDups) & 1, pcp->max_thread_ct, outname, outname_end);
         if (unlikely(reterr)) {
@@ -3907,6 +3918,8 @@ int main(int argc, char** argv) {
   InitTwentythree(&pc.twenty_three_info);
   pc.update_map_flag = nullptr;
   pc.update_name_flag = nullptr;
+  pc.perm_pheno_name = nullptr;
+  pc.perm_pheno_ct = 0;
   pc.update_sample_ids_fname = nullptr;
   pc.update_parental_ids_fname = nullptr;
   pc.recover_var_ids_fname = nullptr;
@@ -8920,6 +8933,31 @@ int main(int argc, char** argv) {
             goto main_ret_INVALID_CMDLINE;
           }
 #endif
+        } else if (strequal_k_unsafe(flagname_p2, "ake-perm-pheno")) {
+          if (unlikely(EnforceParamCtRange(argvk[arg_idx], param_ct, 1, 3))) {
+            goto main_ret_INVALID_CMDLINE_2A;
+          }
+          if (unlikely(ScanPosintDefcap(argvk[arg_idx + 1], &pc.perm_pheno_ct))) {
+            snprintf(g_logbuf, kLogbufSize, "Error: Invalid --make-perm-pheno permutation count '%s'.\n", argvk[arg_idx + 1]);
+            goto main_ret_INVALID_CMDLINE_WWA;
+          }
+          for (uint32_t param_idx = 2; param_idx <= param_ct; ++param_idx) {
+            const char* cur_modif = argvk[arg_idx + param_idx];
+            const uint32_t cur_modif_slen = strlen(cur_modif);
+            if (strequal_k(cur_modif, "zs", cur_modif_slen)) {
+              pc.misc_flags |= kfMiscMakePermPhenoZs;
+            } else if (likely(!pc.perm_pheno_name)) {
+              reterr = CmdlineAllocString(cur_modif, "--make-perm-pheno", kMaxIdSlen, &pc.perm_pheno_name);
+              if (unlikely(reterr)) {
+                goto main_ret_1;
+              }
+            } else {
+              snprintf(g_logbuf, kLogbufSize, "Error: Invalid --make-perm-pheno argument '%s'.\n", cur_modif);
+              goto main_ret_INVALID_CMDLINE_WWA;
+            }
+          }
+          pc.command_flags1 |= kfCommand1MakePermPheno;
+          pc.dependency_flags |= kfFilterPsamReq;
         } else if (strequal_k_unsafe(flagname_p2, "ake-bed")) {
           if (unlikely(pc.exportf_info.flags & kfExportfIndMajorBed)) {
             logerrputs("Error: --make-bed cannot be used with --export ind-major-bed.\n");
@@ -14467,6 +14505,7 @@ int main(int argc, char** argv) {
   free_cond(rseeds);
   CleanupPlink2CmdlineMeta(&pcm);
   CleanupAdjust(&adjust_file_info);
+  free_cond(pc.perm_pheno_name);
   free_cond(king_cutoff_fprefix);
   free_cond(pc.zero_cluster_phenoname);
   free_cond(pc.zero_cluster_fname);

--- a/2.0/plink2_common.h
+++ b/2.0/plink2_common.h
@@ -172,7 +172,8 @@ FLAGSET64_DEF_START()
   kfMiscNeg9PhenoReallyMissing = (1LLU << 47),
   kfMiscAlt1Allele = (1LLU << 48),
   kfMiscSelectSidParentsOnly = (1LLU << 49),
-  kfMiscZeroCms = (1LLU << 50)
+  kfMiscZeroCms = (1LLU << 50),
+  kfMiscMakePermPhenoZs = (1LLU << 51)
 FLAGSET64_DEF_END(MiscFlags);
 
 FLAGSET64_DEF_START()

--- a/2.0/plink2_help.cc
+++ b/2.0/plink2_help.cc
@@ -1690,6 +1690,19 @@ PglErr DispHelp(const char* const* argvk, uint32_t param_ct) {
 "  --write-samples\n"
 "    Report IDs of all samples which pass your filters/inclusion thresholds.\n\n"
                );
+    HelpPrint("make-perm-pheno\0", &help_ctrl, 1,
+"  --make-perm-pheno <ct> [phenotype name] ['zs']\n"
+"    Write the given number of phenotype permutations to\n"
+"    <output prefix>.pphe, without running an association test.  Name the\n"
+"    phenotype when more than one is loaded.\n"
+"    * Only samples with a nonmissing phenotype take part; the rest keep the\n"
+"      missing-phenotype string in every column.\n"
+"    * Each column is an independent shuffle of the same values, so the case\n"
+"      count, or the quantitative distribution, is preserved exactly.\n"
+"    * --seed makes the result reproducible.\n"
+"    * PLINK 1.x could restrict permutation to within --within clusters; that\n"
+"      is not supported here yet, so the shuffle is unrestricted.\n\n"
+               );
     HelpPrint("write-snplist\0", &help_ctrl, 1,
 "  --write-snplist ['zs'] ['allow-dups']\n"
 "    List all variants which pass your filters/inclusion thresholds.  Unless the\n"

--- a/2.0/plink2_misc.cc
+++ b/2.0/plink2_misc.cc
@@ -33,6 +33,7 @@
 #include "plink2_cmdline.h"
 #include "plink2_compress_stream.h"
 #include "plink2_decompress.h"
+#include "plink2_random.h"
 #include "plink2_data.h"
 
 #ifdef __cplusplus
@@ -14367,6 +14368,169 @@ PglErr CheckAlleleUniqueness(const uintptr_t* variant_include, const ChrInfo* ci
     break;
   }
   CleanupThreads(&tg);
+  BigstackReset(bigstack_mark);
+  return reterr;
+}
+
+PglErr MakePermPheno(const uintptr_t* sample_include, const SampleIdInfo* siip, const PhenoCol* pheno_cols, const char* pheno_names, const char* pheno_name, const char* output_missing_pheno, uint32_t raw_sample_ct, uint32_t sample_ct, uint32_t pheno_ct, uintptr_t max_pheno_name_blen, uint32_t perm_ct, uint32_t output_zst, uint32_t max_thread_ct, sfmt_t* sfmtp, char* outname, char* outname_end) {
+  unsigned char* bigstack_mark = g_bigstack_base;
+  char* cswritep = nullptr;
+  CompressStreamState css;
+  PreinitCstream(&css);
+  PglErr reterr = kPglRetSuccess;
+  {
+    const PhenoCol* pheno_col = nullptr;
+    if (pheno_name) {
+      const uintptr_t name_blen = 1 + strlen(pheno_name);
+      for (uint32_t pheno_idx = 0; pheno_idx != pheno_ct; ++pheno_idx) {
+        if (memequal(pheno_name, &(pheno_names[pheno_idx * max_pheno_name_blen]), name_blen)) {
+          pheno_col = &(pheno_cols[pheno_idx]);
+          break;
+        }
+      }
+      if (unlikely(!pheno_col)) {
+        logerrprintfww("Error: --make-perm-pheno phenotype '%s' not found.\n", pheno_name);
+        goto MakePermPheno_ret_INCONSISTENT_INPUT;
+      }
+    } else {
+      if (unlikely(!pheno_ct)) {
+        logerrputs("Error: --make-perm-pheno requires phenotype data.\n");
+        goto MakePermPheno_ret_INCONSISTENT_INPUT;
+      }
+      if (unlikely(pheno_ct > 1)) {
+        logerrputs("Error: More than one phenotype is loaded; name the one --make-perm-pheno\nshould permute.\n");
+        goto MakePermPheno_ret_INCONSISTENT_INPUT;
+      }
+      pheno_col = &(pheno_cols[0]);
+    }
+    const uint32_t is_cc = (pheno_col->type_code == kPhenoDtypeCc);
+    if (unlikely((!is_cc) && (pheno_col->type_code != kPhenoDtypeQt))) {
+      logerrputs("Error: --make-perm-pheno's phenotype must be case/control or quantitative.\n");
+      goto MakePermPheno_ret_INCONSISTENT_INPUT;
+    }
+
+    const uint32_t raw_sample_ctl = BitCtToWordCt(raw_sample_ct);
+    uintptr_t* nm_sample_include;
+    if (unlikely(bigstack_alloc_w(raw_sample_ctl, &nm_sample_include))) {
+      goto MakePermPheno_ret_NOMEM;
+    }
+    BitvecAndCopy(sample_include, pheno_col->nonmiss, raw_sample_ctl, nm_sample_include);
+    const uint32_t nm_ct = PopcountWords(nm_sample_include, raw_sample_ctl);
+    if (unlikely(nm_ct < 2)) {
+      logerrputs("Error: --make-perm-pheno requires at least two samples with a nonmissing\nphenotype.\n");
+      goto MakePermPheno_ret_INCONSISTENT_INPUT;
+    }
+
+    // The values to be shuffled, in nonmissing-sample order, and the column of
+    // permuted values for one sample.  Permutations are generated one at a
+    // time and transposed into perm_vals, so that only one shuffle buffer is
+    // needed regardless of perm_ct.
+    double* base_vals;
+    double* shuffled;
+    double* perm_vals;
+    uint32_t* nm_idx_to_sample_uidx;
+    if (unlikely(bigstack_alloc_d(nm_ct, &base_vals) ||
+                 bigstack_alloc_d(nm_ct, &shuffled) ||
+                 bigstack_alloc_d(S_CAST(uintptr_t, nm_ct) * perm_ct, &perm_vals) ||
+                 bigstack_alloc_u32(nm_ct, &nm_idx_to_sample_uidx))) {
+      goto MakePermPheno_ret_NOMEM;
+    }
+    {
+      uintptr_t sample_uidx_base = 0;
+      uintptr_t cur_bits = nm_sample_include[0];
+      for (uint32_t nm_idx = 0; nm_idx != nm_ct; ++nm_idx) {
+        const uintptr_t sample_uidx = BitIter1(nm_sample_include, &sample_uidx_base, &cur_bits);
+        nm_idx_to_sample_uidx[nm_idx] = sample_uidx;
+        base_vals[nm_idx] = is_cc? (IsSet(pheno_col->data.cc, sample_uidx)? 2.0 : 1.0) : pheno_col->data.qt[sample_uidx];
+      }
+    }
+    for (uint32_t perm_idx = 0; perm_idx != perm_ct; ++perm_idx) {
+      memcpy(shuffled, base_vals, nm_ct * sizeof(double));
+      // Fisher-Yates.  RandU32() is unbiased, unlike the modulo shortcut.
+      for (uint32_t uii = nm_ct - 1; uii; --uii) {
+        const uint32_t ujj = RandU32(uii + 1, sfmtp);
+        const double tmp = shuffled[uii];
+        shuffled[uii] = shuffled[ujj];
+        shuffled[ujj] = tmp;
+      }
+      for (uint32_t nm_idx = 0; nm_idx != nm_ct; ++nm_idx) {
+        perm_vals[S_CAST(uintptr_t, nm_idx) * perm_ct + perm_idx] = shuffled[nm_idx];
+      }
+    }
+
+    OutnameZstSet(".pphe", output_zst, outname_end);
+    const uint32_t omp_slen = strlen(output_missing_pheno);
+    const uintptr_t overflow_buf_size = kCompressStreamBlock + kMaxIdSlen + S_CAST(uintptr_t, perm_ct) * MAXV(kMaxDoubleGSlen + 1, omp_slen + 1) + 256;
+    reterr = InitCstreamAlloc(outname, 0, output_zst, MAXV(max_thread_ct - 1, 1), overflow_buf_size, &css, &cswritep);
+    if (unlikely(reterr)) {
+      goto MakePermPheno_ret_1;
+    }
+    const uint32_t write_fid = DataFidColIsRequired(sample_include, siip, sample_ct, 1);
+    const uint32_t write_sid = DataSidColIsRequired(sample_include, siip->sids, sample_ct, siip->max_sid_blen, 1);
+    *cswritep++ = '#';
+    if (write_fid) {
+      cswritep = strcpya_k(cswritep, "FID\t");
+    }
+    cswritep = strcpya_k(cswritep, "IID");
+    if (write_sid) {
+      cswritep = strcpya_k(cswritep, "\tSID");
+    }
+    for (uint32_t perm_idx = 0; perm_idx != perm_ct; ++perm_idx) {
+      cswritep = strcpya_k(cswritep, "\tPERM");
+      cswritep = u32toa(perm_idx + 1, cswritep);
+    }
+    AppendBinaryEoln(&cswritep);
+
+    const char* sample_ids = siip->sample_ids;
+    const char* sids = siip->sids;
+    const uintptr_t max_sample_id_blen = siip->max_sample_id_blen;
+    const uintptr_t max_sid_blen = siip->max_sid_blen;
+    uintptr_t sample_uidx_base = 0;
+    uintptr_t cur_bits = sample_include[0];
+    uint32_t nm_idx = 0;
+    for (uint32_t sample_idx = 0; sample_idx != sample_ct; ++sample_idx) {
+      const uintptr_t sample_uidx = BitIter1(sample_include, &sample_uidx_base, &cur_bits);
+      cswritep = AppendXid(sample_ids, sids, write_fid, write_sid, max_sample_id_blen, max_sid_blen, sample_uidx, cswritep);
+      if (!IsSet(nm_sample_include, sample_uidx)) {
+        for (uint32_t perm_idx = 0; perm_idx != perm_ct; ++perm_idx) {
+          *cswritep++ = '\t';
+          cswritep = memcpya(cswritep, output_missing_pheno, omp_slen);
+        }
+      } else {
+        const double* cur_vals = &(perm_vals[S_CAST(uintptr_t, nm_idx) * perm_ct]);
+        for (uint32_t perm_idx = 0; perm_idx != perm_ct; ++perm_idx) {
+          *cswritep++ = '\t';
+          if (is_cc) {
+            *cswritep++ = (cur_vals[perm_idx] == 2.0)? '2' : '1';
+          } else {
+            cswritep = dtoa_g(cur_vals[perm_idx], cswritep);
+          }
+        }
+        ++nm_idx;
+      }
+      AppendBinaryEoln(&cswritep);
+      if (unlikely(Cswrite(&css, &cswritep))) {
+        goto MakePermPheno_ret_WRITE_FAIL;
+      }
+    }
+    if (unlikely(CswriteCloseNull(&css, cswritep))) {
+      goto MakePermPheno_ret_WRITE_FAIL;
+    }
+    logprintfww("--make-perm-pheno: %u permutation%s of %u nonmissing phenotype%s written to %s .\n", perm_ct, (perm_ct == 1)? "" : "s", nm_ct, (nm_ct == 1)? "" : "s", outname);
+  }
+  while (0) {
+  MakePermPheno_ret_NOMEM:
+    reterr = kPglRetNomem;
+    break;
+  MakePermPheno_ret_WRITE_FAIL:
+    reterr = kPglRetWriteFail;
+    break;
+  MakePermPheno_ret_INCONSISTENT_INPUT:
+    reterr = kPglRetInconsistentInput;
+    break;
+  }
+ MakePermPheno_ret_1:
+  CswriteCloseCond(&css, cswritep);
   BigstackReset(bigstack_mark);
   return reterr;
 }

--- a/2.0/plink2_misc.h
+++ b/2.0/plink2_misc.h
@@ -21,10 +21,13 @@
 #include "include/pgenlib_read.h"
 #include "include/plink2_base.h"
 #include "plink2_common.h"
+#include "plink2_random.h"
 
 #ifdef __cplusplus
 namespace plink2 {
 #endif
+
+PglErr MakePermPheno(const uintptr_t* sample_include, const SampleIdInfo* siip, const PhenoCol* pheno_cols, const char* pheno_names, const char* pheno_name, const char* output_missing_pheno, uint32_t raw_sample_ct, uint32_t sample_ct, uint32_t pheno_ct, uintptr_t max_pheno_name_blen, uint32_t perm_ct, uint32_t output_zst, uint32_t max_thread_ct, sfmt_t* sfmtp, char* outname, char* outname_end);
 
 FLAGSET_DEF_START()
   kfRecoverVarIds0,


### PR DESCRIPTION
PLINK 1.9's `--make-perm-pheno` writes a file of permuted copies of a phenotype, for use as the input of an externally-scripted permutation test. This ports it to PLINK 2.0.

```
--make-perm-pheno <ct> [pheno name] [zs]
```

Differences from PLINK 1.9, all of which follow PLINK 2.0 conventions:

- the phenotype may be named, so the flag is usable when more than one is loaded (1.9 errors out);
- the output is an ordinary `.pphe` with a `#FID`/`IID` header rather than a headerless file;
- `zs` compresses the output.

Fisher-Yates with `RandU32()`, which is unbiased, and one shuffle buffer regardless of the permutation count.

## Testing

`Tests/TEST_MAKE_PERM_PHENO`. The values cannot be compared against PLINK 1.9, since the two draw from different random streams, so the test checks the invariants instead:

- every column is a rearrangement of the input values (case/control and quantitative);
- a sample whose phenotype is missing stays missing in every column;
- the columns are distinct from each other;
- the same `--seed` reproduces the file, a different seed changes it;
- `zs` round-trips through `--zst-decompress`;
- naming the phenotype is required when more than one is loaded, and naming it works.

The rest of `2.0/Tests` passes. `TEST_DISTANCE` fails in my environment only because the `plink` on my PATH is a Homebrew build of b.7.11, which predates the 7 Sep 2026 `bin4` diagonal bugfix that the test now expects; it is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
