### PR TITLE
Reject 1-bit records with an out-of-range genotype code

### DIFF
--- a/2.0/Tests/TEST_PGEN_MALFORMED/.gitignore
+++ b/2.0/Tests/TEST_PGEN_MALFORMED/.gitignore
@@ -1,0 +1,3 @@
+plink2_*
+tmp_*
+*.log

--- a/2.0/Tests/TEST_PGEN_MALFORMED/run_tests.sh
+++ b/2.0/Tests/TEST_PGEN_MALFORMED/run_tests.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# A .pgen record whose type byte says "1-bit" but whose body is not a valid
+# 1-bit record must be rejected, not counted.
+#
+# The first body byte of a 1-bit record packs two genotype codes, and
+# CountparseOnebitSubset() uses both of them to index a four-element
+# genocounts[] array.  Before the accompanying fix, a corrupted byte indexed
+# that array with a value of up to 66, and --freq still exited 0 with a report
+# full of wrong numbers.
+
+set -exo pipefail
+
+$1/plink2 $2 $3 --dummy 400 600 --seed 1 --make-pgen --out tmp_data
+
+# Sanity check: the unmodified fileset is fine.
+$1/plink2 $2 $3 --pfile tmp_data --freq --out plink2_ok
+test "$(grep -cv '^#' plink2_ok.afreq)" -eq 600
+
+# Byte 92 is inside the record-type array, and setting it to 0x91 marks a
+# record as 1-bit whose body then decodes to an out-of-range genotype code.
+# (If a .pgen layout change moves that array, this offset is what needs
+# updating; the scan that found it just tried every header byte.)
+python3 -c "
+b = bytearray(open('tmp_data.pgen', 'rb').read())
+b[92] = 0x91
+open('tmp_bad.pgen', 'wb').write(bytes(b))
+"
+cp tmp_data.pvar tmp_bad.pvar
+cp tmp_data.psam tmp_bad.psam
+
+# --validate has always caught this one.
+if $1/plink2 $2 $3 --pfile tmp_bad --validate --out plink2_val 2> tmp_val_err.txt; then
+    echo "expected --validate to reject the corrupted .pgen"
+    exit 1
+fi
+grep -q "Invalid 1-bit genotype record" tmp_val_err.txt
+
+# --freq has to reject it too, rather than reporting counts.
+if $1/plink2 $2 $3 --pfile tmp_bad --freq --out plink2_bad 2> tmp_err.txt; then
+    echo "expected --freq to reject the corrupted .pgen"
+    exit 1
+fi
+grep -q "Failed to unpack" tmp_err.txt
+test ! -e plink2_bad.afreq

--- a/2.0/Tests/run_tests.sh
+++ b/2.0/Tests/run_tests.sh
@@ -118,4 +118,9 @@ cd TEST_SHOW_TAGS
 cd ..
 echo "TEST_SHOW_TAGS passed."
 
+cd TEST_PGEN_MALFORMED
+./run_tests.sh $d $2 $3 > TEST_PGEN_MALFORMED.log
+cd ..
+echo "TEST_PGEN_MALFORMED passed."
+
 echo "All tests passed."

--- a/2.0/include/pgenlib_read.cc
+++ b/2.0/include/pgenlib_read.cc
@@ -3523,7 +3523,13 @@ PglErr CountparseOnebitSubset(const unsigned char* fread_end, const uintptr_t* _
   }
   const uint32_t common2_code = *onebit_main_iter++;
   const uint32_t geno_code_low = common2_code / 4;
-  const uint32_t geno_code_high = (common2_code & 3) + geno_code_low;
+  const uint32_t common_code_delta = common2_code & 3;
+  // Both codes index genocounts[], so a corrupted byte here would otherwise
+  // write outside it.  ValidateOnebit() applies the same test.
+  if (unlikely((!common_code_delta) || (geno_code_low + common_code_delta > 3))) {
+    return kPglRetMalformedInput;
+  }
+  const uint32_t geno_code_high = common_code_delta + geno_code_low;
   uint32_t high_geno_ct;
   if (raw_sample_ct == sample_ct) {
     high_geno_ct = PopcountBytes(onebit_main_iter, initial_bitarray_byte_ct);


### PR DESCRIPTION
`CountparseOnebitSubset()` reads the first body byte of a 1-bit record as `common2_code`, derives two genotype codes from it, and uses both to index a four-element `genocounts[]` array:

```c
const uint32_t common2_code = *onebit_main_iter++;
const uint32_t geno_code_low = common2_code / 4;                    // 0..63
const uint32_t geno_code_high = (common2_code & 3) + geno_code_low; // 0..66
...
genocounts[geno_code_low] = sample_ct - high_geno_ct;
genocounts[geno_code_high] = high_geno_ct;
```

Neither code is checked, so one corrupted byte writes outside `genocounts[]` at a file-controlled offset. `ValidateOnebit()` already rejects exactly this byte, so this applies the same test and reports the record as malformed.

## Reproducing

```
plink2 --dummy 400 600 --seed 1 --make-pgen --out d
python3 -c "b = bytearray(open('d.pgen','rb').read()); b[92] = 0x91; open('x.pgen','wb').write(bytes(b))"
cp d.pvar x.pvar; cp d.psam x.psam
plink2 --pfile x --freq --out x
```

Byte 92 is inside the record-type array; setting it to 0x91 marks one record as 1-bit, and its body then decodes to an out-of-range genotype code.

Before this change, on an ordinary build that command **exits 0** and writes an `.afreq` in which the affected variant's row is silently wrong, having written outside `genocounts[]` on the way:

```
$ diff clean.afreq bad.afreq
145c145
< 1	snp144	B	A	0.34375	800
---
> 1	snp144	B	A	0.323529	34
``` `--validate` on the same file has always reported `Error: Invalid 1-bit genotype record for (0-based) variant #144.`, so the file is unambiguously malformed; `--freq` just didn't notice.

With `-fsanitize=address`:

```
==91327==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x00016f5469c8
WRITE of size 4
    #0 plink2::CountparseOnebitSubset(...) pgenlib_read.cc:3545
    #1 plink2::GetBasicGenotypeCounts(...) pgenlib_read.cc:3692
    #2 plink2::GetBasicGenotypeCountsAndDosage16s(...) pgenlib_read.cc:7933
    #3 plink2::LoadAlleleAndGenoCountsThread(void*) plink2_data.cc:2424
```

After the change, the same command reports `Error: Failed to unpack (0-based) variant #144 in .pgen file.` and writes nothing.

I found this by fuzzing: 80 single-to-quadruple byte mutations of a valid .pgen, each run through `--validate`, `--freq`, `--make-bed`, `--geno-counts`, `--hardy` and `--missing` under `-fsanitize=address,undefined`. Five mutants tripped this; nothing else fired. After the fix all 480 runs are clean.

`CountparseDifflistSubset()`, the other function that indexes `genocounts[]` by a code, takes `vrtype & 3` from its caller and is already bounded. `ParseOnebitUnsafe()` uses `common2_code` too, but only to build a word pattern, so an out-of-range value there gives wrong genotypes rather than an out-of-bounds access — and it is named `Unsafe`.

## Testing

New `Tests/TEST_PGEN_MALFORMED`, which builds the fixture above, checks the unmodified fileset still works, and asserts that both `--validate` and `--freq` reject the corrupted one. It fails on master (`--freq` exits 0) and passes with this change, without needing a sanitizer build.

The rest of `2.0/Tests` passes. `TEST_DISTANCE` fails in my environment only because the `plink` on my PATH is a Homebrew build of b.7.11, which predates the 7 Sep 2026 `bin4` diagonal bugfix that the test now expects; it is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
