### PR TITLE
1.9: reject --distance-wts with --distance's 'flat-missing' modifier

### DIFF
--- a/1.9/plink.c
+++ b/1.9/plink.c
@@ -12903,6 +12903,15 @@ int32_t main(int32_t argc, char** argv) {
     logerrprint("Error: --distance-wts must be used with --distance, --make-rel, --make-grm-bin,\nor --make-grm-gz.\n");
     goto main_ret_INVALID_CMDLINE_A;
   }
+  if ((distance_wts_fname || (distance_exp != 0.0)) && (dist_calc_type & DISTANCE_FLAT_MISSING)) {
+    // calc_distance() applies the weighted missingness correction whenever
+    // variant weights are in play, so the flat correction the user asked for
+    // would be silently ignored.  (The flat branch does have a main_weights
+    // case, but the counts it needs are only accumulated by the unweighted
+    // path, so reaching it would just divide by zero-filled arrays.)
+    logerrprint("Error: --distance-wts/--distance-exp cannot be used with --distance's\n'flat-missing' modifier.\n");
+    goto main_ret_INVALID_CMDLINE_A;
+  }
   if ((parallel_tot > 1) && (!(calculation_type & (CALC_LD | CALC_DISTANCE | CALC_GENOME | CALC_RELATIONSHIP)))) {
     if ((!(calculation_type & CALC_EPI)) || (!(epi_info.modifier & (EPI_FAST | EPI_REG)))) {
       logerrprint("Error: --parallel only affects --r/--r2, --distance, --genome, --make-rel,\n--make-grm-gz/--make-grm-bin, and --epistasis/--fast-epistasis.\n");


### PR DESCRIPTION
`--distance flat-missing --distance-wts <file>` silently ignores `flat-missing` and applies the weighted missingness correction instead, producing a differently normalized matrix than the one asked for. The documented `--distance-wts exp=<x>` spelling is affected the same way, so this is reachable from a stable `1.9.0-rc1` build.

## Why

`calc_distance()` chooses the correction with

```c
uint32_t unweighted_and_flat = (... || (dist_calc_type & DISTANCE_FLAT_MISSING)) && (!distance_wts_fname) && (distance_exp == 0.0);
uint32_t missing_wt_needed = (...) && (!unweighted_and_flat);
...
if (missing_wt_needed) {
  /* weighted correction */
} else if (dist_calc_type & DISTANCE_FLAT_MISSING) {
  /* flat correction, including a main_weights case */
}
```

With weights, `unweighted_and_flat` is 0 by construction, so `missing_wt_needed` is 1 and the first branch always wins. `DISTANCE_FLAT_MISSING` is only ever set by `--distance`'s modifier, and that same parse block sets `CALC_DISTANCE`, so the `else if` can never be taken when weights are supplied. The `main_weights` case inside it is dead code.

I tried making the flat branch reachable instead. Two things go wrong, which is presumably why it is the way it is:

1. `sample_missing` is only allocated under `missing_wt_needed`, but the allele-count accumulation loop writes to it unconditionally, so the run segfaults at `plink_calc.c:7992`.
2. With that allocation fixed, the flat branch runs but rescales by `marker_ct / (uii - sample_missing_unwt[j] + missing_dbl_excluded[pair])`, and neither `sample_missing_unwt` nor `missing_dbl_excluded` is accumulated by the weighted path — they stay zero, so the factor is 1 and the correction does nothing.

Making it work properly means accumulating the unweighted missingness counts in the bit-parallel weighted loop as well. That is not something I would want to land untested during a release candidate, so this rejects the combination instead, which is what `--distance-wts` already does for `--distance-matrix` and `--distance-exp`.

## Demonstration

4 samples, 10 variants, exactly one missing call (sample 0, variant 0), all weights 1:

```
plain, default          : 6.73528
plain, flat-missing     : 6.66667
--distance-wts, default : 6.73528
--distance-wts, flat    : 6.73528   <- flat-missing ignored
```

The weighted run with all weights equal to 1 reproduces the *default* correction exactly, and `flat-missing` changes nothing. The unweighted flat result is `raw * m / (variants nonmissing in both)`, which is what the modifier is supposed to give.

## What is not affected

`--distance-wts` itself is correct where it is defined. On a fixture with no missing calls, the output matches `sum_v w_v * |g_i - g_j|` to 1.8e-15 over all pairs, and header/`noheader` parsing agree. On a 40x1000 fixture, `--threads 1` and `--threads 8` are byte-identical.

## Testing

After the change, on the fixture above:

```
exit=5 : --distance square flat-missing --distance-wts ones.txt
exit=5 : --distance square flat-missing --distance-wts exp=1
exit=0 : --distance square --distance-wts ones.txt
exit=0 : --distance square --distance-wts exp=1
exit=0 : --distance square flat-missing
exit=0 : --distance square
```

with the last four byte-identical to before. `--make-rel`, `--make-grm-gz` (the other `--distance-wts` call site), `--distance-matrix`, `--ibs-matrix` and `--distance ibs flat-missing` are unaffected.

Builds clean both with and without `-DSTABLE_BUILD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
