### PR TITLE
1.9: fix --homozyg group assertion failure

### DIFF
--- a/1.9/plink_homozyg.c
+++ b/1.9/plink_homozyg.c
@@ -1699,7 +1699,11 @@ int32_t roh_pool(Homozyg_info* hp, FILE* bedfile, uint64_t bed_offset, char* out
           if (slot_idx1 == max_pool_size) {
 	    break;
 	  }
-          clear_bits((((uintptr_t)slot_idx1) * (slot_idx1 - 1)) / 2, slot_idx1, allelic_match_matrix);
+          // slot 0's row of the triangular matrix is empty, and clear_bits()
+          // requires a nonzero length.
+          if (slot_idx1) {
+            clear_bits((((uintptr_t)slot_idx1) * (slot_idx1 - 1)) / 2, slot_idx1, allelic_match_matrix);
+          }
           slot_idx1++;
 	}
       } else {
@@ -1714,7 +1718,9 @@ int32_t roh_pool(Homozyg_info* hp, FILE* bedfile, uint64_t bed_offset, char* out
 	if (roh_slot_end_uidx[slot_idx1] <= con_uidx2) {
           CLEAR_BIT(slot_idx1, roh_slot_occupied);
           if (!is_consensus_match) {
-            clear_bits((((uintptr_t)slot_idx1) * (slot_idx1 - 1)) / 2, slot_idx1, allelic_match_matrix);
+            if (slot_idx1) {
+              clear_bits((((uintptr_t)slot_idx1) * (slot_idx1 - 1)) / 2, slot_idx1, allelic_match_matrix);
+            }
 	    slot_idx2 = slot_idx1;
 	    while (1) {
               slot_idx2 = next_set(roh_slot_occupied, slot_idx2 + 1, max_pool_size);


### PR DESCRIPTION
`--homozyg group` aborts on an assertion as soon as the first occupied ROH slot is slot 0, which is the ordinary case:

```
--homozyg: Scan complete, found 60 ROH.
Results saved to h2.hom + h2.hom.indiv + h2.hom.summary .
22 pools of overlapping ROH present.
Determining within-pool allelic similarity... [chromosome   1] Assertion failed: (len), function clear_bits, file plink_common.c, line 3469.
```

Exit status 134, and no `.hom.overlap` is written. This is not new to the release candidate: the Homebrew build of b.7.11 (19 Aug 2025) fails the same way, at the same assertion.

It is the whole pool-report family, not just plain `group`. On b.7.11, with the fixture below:

```
exit=134 : --homozyg group
exit=134 : --homozyg group-verbose
exit=134 : --homozyg group --homozyg-match 0.9
exit=134 : --homozyg group --pool-size 3
exit=134 : --homozyg group extend
exit=134 : --homozyg group consensus-match
```

All six exit 0 with this change.

## Cause

Row `slot_idx1` of the triangular `allelic_match_matrix` spans bits `[slot_idx1 * (slot_idx1 - 1) / 2, ... + slot_idx1)`, so row 0 is empty and

```c
clear_bits((((uintptr_t)slot_idx1) * (slot_idx1 - 1)) / 2, slot_idx1, allelic_match_matrix);
```

is called with length 0. `clear_bits()` opens with `assert(len)`.

The call is logically right — there is nothing to clear for slot 0 — and the operation is a no-op at length 0 (`maj_start == maj_end`, and the mask reduces to `~0`), so a build with `-DNDEBUG` would behave correctly. The Makefile doesn't define `NDEBUG`, which is why released binaries abort. This guards the two call sites rather than relaxing the assertion, since the precondition is deliberate.

## Reproducing

```python
import random
rand = random.Random(5)
n_s, n_v = 60, 3000
with open('r.map', 'w') as f:
    for j in range(n_v):
        f.write('1\tv%d\t0\t%d\n' % (j, (j + 1) * 5000))
def al(g):
    return {0: 'A A', 1: 'A C', 2: 'C C'}[g]
rows = []
for i in range(n_s):
    g = [rand.choice([0, 1, 1, 2]) for _ in range(n_v)]
    start = rand.randrange(0, n_v - 600)
    for j in range(start, start + 600):
        g[j] = 0                      # plant a run of homozygosity
    rows.append('f%d i%d 0 0 1 %d %s' % (i, i, 1 + (i % 2), ' '.join(al(x) for x in g)))
open('r.ped', 'w').write('\n'.join(rows) + '\n')
```

then `plink --file r --allow-no-sex --homozyg group --out h`.

## Testing

With the fix, that command exits 0 and writes the missing `.hom.overlap` (442 lines, the 22 pools the log reports, with the `GRP` column populated). `.hom`, `.hom.indiv` and `.hom.summary` are byte-identical to the plain `--homozyg` run, and `--homozyg` on its own, `consensus-match` and `extend` are unaffected.

Found while sweeping 1.9 for flag/modifier combinations whose output doesn't change when it should; this one turned out to crash rather than merely be ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
