### PR TITLE
1.9: keep --homozyg group members in their first (highest-NSIM) group

### DIFF
--- a/1.9/plink_homozyg.c
+++ b/1.9/plink_homozyg.c
@@ -1291,15 +1291,19 @@ void assign_allelic_match_groups(uint32_t pool_size, uint32_t* allelic_match_cts
 	tri_coord = tri_coord_no_diag(main_slot_idx, slot_idx2);
       }
       if (IS_SET(allelic_match_matrix, tri_coord)) {
+	// Groups are assigned greedily, in decreasing order of NSIM, so an ROH
+	// which already belongs to a group must stay in it.  Otherwise a
+	// later, lower-NSIM group steals members from an earlier one, and the
+	// earlier group ends up with fewer than NSIM + 1 entries.
 	if (allelic_match_cts[pool_idx] != 0xffffffffU) {
 	  nsim_nz_ct--;
 	  allelic_match_cts[pool_idx] = 0xffffffffU;
-	}
 #ifdef __LP64__
-        cur_pool[pool_idx] = (cur_pool[pool_idx] & 0xffffffff00000000LLU) | group_idx;
+	  cur_pool[pool_idx] = (cur_pool[pool_idx] & 0xffffffff00000000LLU) | group_idx;
 #else
-        cur_pool[2 * pool_idx] = group_idx;
+	  cur_pool[2 * pool_idx] = group_idx;
 #endif
+	}
       }
     }
 #ifdef __LP64__

--- a/1.9/plink_homozyg.c
+++ b/1.9/plink_homozyg.c
@@ -1699,7 +1699,11 @@ int32_t roh_pool(Homozyg_info* hp, FILE* bedfile, uint64_t bed_offset, char* out
           if (slot_idx1 == max_pool_size) {
 	    break;
 	  }
-          clear_bits((((uintptr_t)slot_idx1) * (slot_idx1 - 1)) / 2, slot_idx1, allelic_match_matrix);
+          // slot 0's row of the triangular matrix is empty, and clear_bits()
+          // requires a nonzero length.
+          if (slot_idx1) {
+            clear_bits((((uintptr_t)slot_idx1) * (slot_idx1 - 1)) / 2, slot_idx1, allelic_match_matrix);
+          }
           slot_idx1++;
 	}
       } else {
@@ -1714,7 +1718,9 @@ int32_t roh_pool(Homozyg_info* hp, FILE* bedfile, uint64_t bed_offset, char* out
 	if (roh_slot_end_uidx[slot_idx1] <= con_uidx2) {
           CLEAR_BIT(slot_idx1, roh_slot_occupied);
           if (!is_consensus_match) {
-            clear_bits((((uintptr_t)slot_idx1) * (slot_idx1 - 1)) / 2, slot_idx1, allelic_match_matrix);
+            if (slot_idx1) {
+              clear_bits((((uintptr_t)slot_idx1) * (slot_idx1 - 1)) / 2, slot_idx1, allelic_match_matrix);
+            }
 	    slot_idx2 = slot_idx1;
 	    while (1) {
               slot_idx2 = next_set(roh_slot_occupied, slot_idx2 + 1, max_pool_size);


### PR DESCRIPTION
This branch carries two commits. The first is #448 (the `clear_bits()` assertion failure), included because without it `--homozyg group` aborts before producing output on the dataset below, so the fix here cannot be exercised. If #448 lands first this rebases away cleanly; if you prefer, merging this PR alone subsumes it.

### The bug

`assign_allelic_match_groups()` walks a pool in decreasing order of NSIM. For each leader it assigns the current group number to every ROH that allelically matches it:

```c
if (IS_SET(allelic_match_matrix, tri_coord)) {
  if (allelic_match_cts[pool_idx] != 0xffffffffU) {
    nsim_nz_ct--;
    allelic_match_cts[pool_idx] = 0xffffffffU;
  }
  cur_pool[pool_idx] = (cur_pool[pool_idx] & 0xffffffff00000000LLU) | group_idx;
}
```

The `allelic_match_cts[] != 0xffffffffU` test guards only the NSIM bookkeeping. The group write below it is unconditional, so an ROH that was already placed in an earlier, higher-NSIM group is silently moved into the later, lower-NSIM one.

That contradicts what the same rows report: the leader of group 1 prints NSIM similar ROHs, and every one of them matched it, so group 1 has to contain exactly NSIM + 1 entries.

### Measurement

60 simulated samples, 22 pools on chr1. Counting pools where the number of group 1 rows differs from the group 1 leader's NSIM + 1:

| run | before | after |
| --- | --- | --- |
| `--homozyg-match 0.8` | 0 of 22 | 0 of 22 |
| `--homozyg-match 0.95` | 0 of 22 | 0 of 22 |
| `--homozyg-match 0.99` | 5 of 22 | 0 of 22 |
| `--homozyg group consensus-match` | 1 of 22 | 0 of 22 |

Example, pool S1 at `--homozyg-match 0.99` before the fix: the leader reports `NSIM 19`, but only 14 rows carry `GRP 1`. The five missing ROHs had been reassigned to later groups.

### The fix

Claim an ROH only if it has not been claimed yet. `allelic_match_cts[]` already tracks exactly that, so the group write moves inside the existing branch. The trailing loop that gives every unclaimed ROH its own singleton group is unchanged.

### Scope of the output change

`.hom`, `.hom.indiv` and `.hom.summary` are byte-identical before and after; only the `GRP` column of `.hom.overlap` moves.

### Independent check

I have a `--homozyg group` port for 2.0 in #450, written from the 1.9 algorithm but with its own group assignment. Before this fix the two disagreed on grouping; after it, `.hom.overlap` agrees row for row at `--homozyg-match` 0.8, 0.95 and 0.99 (419 rows, 0 differences each).

`consensus-match` still differs between the two, for an unrelated reason I am investigating separately: `is_allelic_match()` compares over the 64-marker-aligned window containing the consensus segment rather than the segment itself, so with `consensus-match` it can take up to 63 markers before and 31 markers after the consensus segment into account. In non-consensus mode the padding written by `initialize_roh_slot()` makes that rounding harmless, which is presumably why it went unnoticed. I will send that as its own PR once I have it nailed down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)