### PR TITLE
1.9: confine --homozyg group consensus-match to the consensus segment

### DIFF
--- a/1.9/plink_homozyg.c
+++ b/1.9/plink_homozyg.c
@@ -1291,15 +1291,19 @@ void assign_allelic_match_groups(uint32_t pool_size, uint32_t* allelic_match_cts
 	tri_coord = tri_coord_no_diag(main_slot_idx, slot_idx2);
       }
       if (IS_SET(allelic_match_matrix, tri_coord)) {
+	// Groups are assigned greedily, in decreasing order of NSIM, so an ROH
+	// which already belongs to a group must stay in it.  Otherwise a
+	// later, lower-NSIM group steals members from an earlier one, and the
+	// earlier group ends up with fewer than NSIM + 1 entries.
 	if (allelic_match_cts[pool_idx] != 0xffffffffU) {
 	  nsim_nz_ct--;
 	  allelic_match_cts[pool_idx] = 0xffffffffU;
-	}
 #ifdef __LP64__
-        cur_pool[pool_idx] = (cur_pool[pool_idx] & 0xffffffff00000000LLU) | group_idx;
+	  cur_pool[pool_idx] = (cur_pool[pool_idx] & 0xffffffff00000000LLU) | group_idx;
 #else
-        cur_pool[2 * pool_idx] = group_idx;
+	  cur_pool[2 * pool_idx] = group_idx;
 #endif
+	}
       }
     }
 #ifdef __LP64__

--- a/1.9/plink_homozyg.c
+++ b/1.9/plink_homozyg.c
@@ -1699,7 +1699,11 @@ int32_t roh_pool(Homozyg_info* hp, FILE* bedfile, uint64_t bed_offset, char* out
           if (slot_idx1 == max_pool_size) {
 	    break;
 	  }
-          clear_bits((((uintptr_t)slot_idx1) * (slot_idx1 - 1)) / 2, slot_idx1, allelic_match_matrix);
+          // slot 0's row of the triangular matrix is empty, and clear_bits()
+          // requires a nonzero length.
+          if (slot_idx1) {
+            clear_bits((((uintptr_t)slot_idx1) * (slot_idx1 - 1)) / 2, slot_idx1, allelic_match_matrix);
+          }
           slot_idx1++;
 	}
       } else {
@@ -1714,7 +1718,9 @@ int32_t roh_pool(Homozyg_info* hp, FILE* bedfile, uint64_t bed_offset, char* out
 	if (roh_slot_end_uidx[slot_idx1] <= con_uidx2) {
           CLEAR_BIT(slot_idx1, roh_slot_occupied);
           if (!is_consensus_match) {
-            clear_bits((((uintptr_t)slot_idx1) * (slot_idx1 - 1)) / 2, slot_idx1, allelic_match_matrix);
+            if (slot_idx1) {
+              clear_bits((((uintptr_t)slot_idx1) * (slot_idx1 - 1)) / 2, slot_idx1, allelic_match_matrix);
+            }
 	    slot_idx2 = slot_idx1;
 	    while (1) {
               slot_idx2 = next_set(roh_slot_occupied, slot_idx2 + 1, max_pool_size);

--- a/1.9/plink_homozyg.c
+++ b/1.9/plink_homozyg.c
@@ -911,7 +911,43 @@ int32_t populate_roh_slots_from_disk(FILE* bedfile, uint64_t bed_offset, uintptr
   return 0;
 }
 
+static inline void roh_slot_uncount_range(uintptr_t* roh_slot_idxl, uintptr_t* roh_slot_idxs, uint32_t block_start_idxl, uint32_t block_start_idxs, uint32_t cidx_start, uint32_t cidx_end, uint32_t* joint_homozyg_ctp, uint32_t* joint_homozyg_mismatch_ctp) {
+  // Removes [cidx_start, cidx_end) from an is_allelic_match() tally.  The two
+  // slots' block starts differ by a multiple of the block size, so a given
+  // marker sits at the same bit offset in both.
+  uint32_t offset_idxl = cidx_start - block_start_idxl;
+  uintptr_t* read_ptr_l = &(roh_slot_idxl[offset_idxl / BITCT2]);
+  uintptr_t* read_ptr_s = &(roh_slot_idxs[(cidx_start - block_start_idxs) / BITCT2]);
+  uint32_t bit_offset = offset_idxl % BITCT2;
+  uint32_t markers_left = cidx_end - cidx_start;
+  uintptr_t wloader_l;
+  uintptr_t wloader_s;
+  uintptr_t joint_word;
+  uint32_t cur_marker_ct;
+  while (markers_left) {
+    cur_marker_ct = BITCT2 - bit_offset;
+    if (cur_marker_ct > markers_left) {
+      cur_marker_ct = markers_left;
+    }
+    wloader_l = *read_ptr_l++;
+    wloader_s = *read_ptr_s++;
+    joint_word = (~((wloader_l ^ (wloader_l >> 1)) | (wloader_s ^ (wloader_s >> 1)))) & ((FIVEMASK >> (2 * (BITCT2 - cur_marker_ct))) << (2 * bit_offset));
+    *joint_homozyg_ctp -= popcount2_long(joint_word);
+    *joint_homozyg_mismatch_ctp -= popcount2_long(joint_word & (wloader_l ^ wloader_s));
+    markers_left -= cur_marker_ct;
+    bit_offset = 0;
+  }
+}
+
 static inline uint32_t is_allelic_match(double mismatch_max, uintptr_t* roh_slot_idxl, uintptr_t* roh_slot_idxs, uint32_t block_start_idxl, uint32_t block_start_idxs, uint32_t overlap_cidx_start, uint32_t overlap_cidx_end) {
+  uintptr_t* roh_slot_idxl_base = roh_slot_idxl;
+  uintptr_t* roh_slot_idxs_base = roh_slot_idxs;
+#ifdef __LP64__
+  const uint32_t window_cidx_start = overlap_cidx_start & (~63);
+#else
+  const uint32_t window_cidx_start = overlap_cidx_start & (~15);
+#endif
+  const uint32_t window_cidx_end = ((overlap_cidx_end + (BITCT2 - 1)) / BITCT2) * BITCT2;
 #ifdef __LP64__
   const __m128i m1 = {FIVEMASK, FIVEMASK};
   const __m128i m2 = {0x3333333333333333LLU, 0x3333333333333333LLU};
@@ -1130,6 +1166,21 @@ static inline uint32_t is_allelic_match(double mismatch_max, uintptr_t* roh_slot
     joint_word = (~((wloader_l ^ (wloader_l >> 1)) | (wloader_s ^ (wloader_s >> 1)))) & FIVEMASK;
     joint_homozyg_ct += popcount2_long(joint_word);
     joint_homozyg_mismatch_ct += popcount2_long(joint_word & (wloader_l ^ wloader_s));
+  }
+  // The loops above cover a whole number of blocks/words: everything from
+  // overlap_cidx_start rounded down to the start of its block, through
+  // overlap_cidx_end rounded up to the end of its word.  When the caller's
+  // interval is the intersection of the two ROHs, that rounding is harmless,
+  // since every marker outside the interval is outside at least one of the two
+  // ROHs, and initialize_roh_slot() has written "missing" there.  With
+  // 'consensus-match' the interval is the pool's consensus segment, which is
+  // strictly inside both ROHs, so real genotypes from up to 63 markers before
+  // it and 31 markers after it are counted as well; take them back out.
+  if (window_cidx_start != overlap_cidx_start) {
+    roh_slot_uncount_range(roh_slot_idxl_base, roh_slot_idxs_base, block_start_idxl, block_start_idxs, window_cidx_start, overlap_cidx_start, &joint_homozyg_ct, &joint_homozyg_mismatch_ct);
+  }
+  if (window_cidx_end != overlap_cidx_end) {
+    roh_slot_uncount_range(roh_slot_idxl_base, roh_slot_idxs_base, block_start_idxl, block_start_idxs, overlap_cidx_end, window_cidx_end, &joint_homozyg_ct, &joint_homozyg_mismatch_ct);
   }
   return (((double)((int32_t)joint_homozyg_mismatch_ct)) <= mismatch_max * ((int32_t)joint_homozyg_ct));
 }


### PR DESCRIPTION
Third in a `--homozyg group` series; the branch carries #448 and #451 ahead of it, because without #448 the command aborts on the dataset below and without #451 the grouping is wrong for an unrelated reason. Only the last commit is new here. Each rebases away cleanly if the earlier ones land first.

### The bug

`is_allelic_match()` tallies jointly-homozygous markers and mismatches over a whole number of blocks/words:

```c
uint32_t words_left = ((overlap_cidx_end + 31) / 32) - 2 * (overlap_cidx_start / 64);
...
roh_slot_idxl = &(roh_slot_idxl[2 * ((overlap_cidx_start - block_start_idxl) / 64)]);
roh_slot_idxs = &(roh_slot_idxs[2 * ((overlap_cidx_start - block_start_idxs) / 64)]);
```

so the window it actually walks is `[overlap_cidx_start & ~63, roundup(overlap_cidx_end, 32))`.

In the default mode that rounding costs nothing. `compute_allelic_match_matrix()` passes the intersection of the two ROHs, and every marker outside the intersection is outside at least one of them, where `initialize_roh_slot()` has written `01` (missing) padding, which the joint-homozygosity test rejects.

`consensus-match` passes the pool's consensus segment instead. That segment is strictly inside every ROH in the pool, so the padding no longer covers the rounding, and real genotypes from up to 63 markers before the segment and 31 markers after it end up in the tally.

### Measurement

60 simulated samples, 22 pools, 375 ROHs on chr1. NSIM checked against a direct genotype-by-genotype count over each pool's consensus segment (both samples homozygous, mismatch fraction against `1 - --homozyg-match`):

| | wrong NSIM values |
| --- | --- |
| before | 117 of 375 |
| after | 0 of 375 |

The clearest single case is pool S1. Its consensus segment is `v1035`-`v1062`, 28 markers, over which all 21 members are pairwise allelic matches, so every NSIM should be 20. Before the fix `--homozyg group consensus-match` reports:

```
   S1   f0   i0   ...   19     1
   ...
   S1  f22  i22   ...   20     1*
   S1  f33  i33   ...    2     1
   S1  f36  i36   ...   20     1
```

`i33` carries a heterozygous call ~50 markers before the consensus segment, inside its own ROH but outside the segment; the rounding pulls it in and it disagrees with 18 of the other 20 members there.

### The fix

Subtract `[window_start, overlap_cidx_start)` and `[overlap_cidx_end, window_end)` from the tally, masked a word at a time. The two slots' block starts differ by a multiple of the block size, so a given marker sits at the same bit offset in both and one mask serves for both loads. Both ranges are empty or entirely padding in the default mode, so the subtraction is a no-op there.

I used a scalar per-marker loop first and got identical results; the word-masked version is what is committed since the ranges can be up to 94 markers and this is inside the O(pool_size^2) loop.

### Checks

- `.hom.overlap` in the default mode is byte-identical before and after at `--homozyg-match` 0.8, 0.95 and 0.99.
- After the fix, `--homozyg group` output agrees row for row with the 2.0 port in #450 in all four modes (`consensus-match` and `--homozyg-match` 0.8/0.95/0.99), on three separate datasets, and across `--homozyg-snp`, `--homozyg-kb`, `--homozyg-window-snp`, `--homozyg-window-het`, `--homozyg-density` and `--homozyg-gap` variations. Before it, `consensus-match` disagreed on 123 of 419 rows.
- `group-verbose consensus-match` is fixed by the same change; its NSIM values also check out at 0 of 375 wrong.

I have not tried to work out whether PLINK 1.07 had the same behaviour, so if `consensus-match` output is meant to stay bit-compatible with it, this is worth a second look before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)