### PR TITLE
1.9: reject zero standard errors and zero p-values in --meta-analysis

### DIFF
--- a/1.9/plink_misc.c
+++ b/1.9/plink_misc.c
@@ -5856,11 +5856,18 @@ int32_t meta_analysis(char* input_fnames, char* chrfield_search_order, char* snp
 	if (scan_double(token_ptrs[1], &cur_beta) || (cur_beta == INFINITY) || ((!input_beta) && (!(cur_beta >= 0))) || (input_beta && ((cur_beta != cur_beta) || (cur_beta == -INFINITY)))) {
 	  problem_mask |= 0x10;
 	}
-	if (scan_double(token_ptrs[2], &cur_se) || (!(cur_se >= 0.0)) || (cur_se == INFINITY)) {
+	// A zero standard error is as unusable as a negative one: the
+	// inverse-variance weight is 1 / (se * se), so it turns the whole
+	// variant's estimate into a NaN while still being counted in N.
+	if (scan_double(token_ptrs[2], &cur_se) || (!(cur_se > 0.0)) || (cur_se == INFINITY)) {
 	  problem_mask |= 0x20;
 	}
 	if (weighted_z) {
-	  if (scan_double(token_ptrs[3], &cur_p) || (!(cur_p >= 0.0)) || (cur_p > 1.0)) {
+	  // Same for a p-value of exactly zero: the weighted-Z analysis needs
+	  // a finite z-score, and inverting a zero p-value does not give one.
+	  // BAD_ESS below already rejects the whole line for a value only
+	  // weighted-Z uses.
+	  if (scan_double(token_ptrs[3], &cur_p) || (!(cur_p > 0.0)) || (cur_p > 1.0)) {
 	    problem_mask |= 0x80;
 	  }
 	  if (scan_double(token_ptrs[4], &cur_ess) || (!(cur_ess > 0.0)) || (cur_ess == INFINITY)) {
@@ -6277,11 +6284,11 @@ int32_t meta_analysis(char* input_fnames, char* chrfield_search_order, char* snp
 	  if (!realnum(cur_beta)) {
 	    continue;
 	  }
-	  if (scan_double(token_ptrs[2], &cur_se) || (!(cur_se >= 0.0)) || (cur_se == INFINITY)) {
+	  if (scan_double(token_ptrs[2], &cur_se) || (!(cur_se > 0.0)) || (cur_se == INFINITY)) {
 	    continue;
 	  }
 	  if (weighted_z) {
-	    if (scan_double(token_ptrs[3], &cur_p) || (!(cur_p >= 0.0)) || (cur_p > 1.0)) {
+	    if (scan_double(token_ptrs[3], &cur_p) || (!(cur_p > 0.0)) || (cur_p > 1.0)) {
 	      continue;
 	    }
 	    if (scan_double(token_ptrs[4], &cur_ess) || (!(cur_ess > 0.0)) || (cur_ess == INFINITY)) {


### PR DESCRIPTION
`--meta-analysis` validates each input record and writes the rejects to `.prob` with a reason. Two values pass validation and then make the result unusable.

### Zero standard error

```c
if (scan_double(token_ptrs[2], &cur_se) || (!(cur_se >= 0.0)) || (cur_se == INFINITY)) {
  problem_mask |= 0x20;
}
```

`se == 0` passes. The inverse-variance weight is `1 / (se * se)`, so that record contributes an infinite weight and the weighted mean comes out NaN. The variant is still counted in `N` and still written to the report, so the row claims k studies while every statistic on it is NaN:

```
 CHR          BP            SNP  A1  A2   N           P        P(R)      OR   OR(R)       Q       I
   1           2            rsB   A   G   2          NA          NA     nan     nan      NA     nan
```

A negative standard error is already `BAD_SE`. Zero belongs there too, and then the remaining studies give a usable estimate:

```
   1           2            rsB   A   G   1      0.0027      0.0027  1.3499  1.3499      NA      NA
```

### Zero p-value

Accepted the same way when `weighted-z` is in effect. Inverting it does not give a finite z-score, so `WEIGHTED_Z` and `P(WZ)` come out NaN. `BAD_ESS` already rejects a whole record for an effective sample size that only weighted-Z uses, so `BAD_P` is consistent with how the command already treats that class of value.

Both values come out of real association software: a monomorphic or otherwise degenerate variant gets SE 0, and a p-value below the printing precision gets rounded to 0.

### Measurement

20 simulated 4-study meta-analyses, 5% of records carrying a zero standard error, 3943 result rows:

| | rows with NaN or NA statistics |
| --- | ---: |
| before | 679 |
| after | 0 |

### No change on well-formed input

120 runs across 2, 3 and 5 studies with 10% allele mismatches: output byte-identical to master.

Those runs also agree field for field with an independent Python implementation of both analyses (inverse-variance fixed and random effects, Cochran's Q, I², and the METAL weighted-Z), which is how I came to look at the degenerate cases in the first place. The only column that ever differs is `WEIGHTED_Z`, on roughly one variant in fifty, always one where some study reports p very close to 1; that is the accuracy of inverting a p-value near 1 rather than a disagreement about the method, and this PR does not touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)