### PR TITLE
1.9: stop --flip-scan from silently shrinking its window

### DIFF
--- a/1.9/plink_ld.c
+++ b/1.9/plink_ld.c
@@ -1786,12 +1786,24 @@ int32_t flipscan(Ld_info* ldip, FILE* bedfile, uintptr_t bed_offset, uintptr_t m
       }
       // only need to enforce window locus count constraint during first loop
       // iteration
-      ulii = window_cidx2 + max_window_locus_ct;
-      if (ulii >= max_window_size) {
-	ulii -= max_window_size;
+      // bugfix (10 Sep 2026): max_window_size is the largest number of markers
+      // the bp window can hold, so when it is no larger than
+      // max_window_locus_ct, the locus count constraint cannot bind and the
+      // circular-buffer arithmetic below does not describe it.  Reducing
+      // window_cidx2 + max_window_locus_ct by a single max_window_size in that
+      // case made the trailing marker flush after only
+      // (max_window_locus_ct % max_window_size) further markers, silently
+      // shrinking every window.
+      uint32_t count_flush = 0;
+      if (max_window_locus_ct < max_window_size) {
+        ulii = window_cidx2 + max_window_locus_ct;
+        if (ulii >= max_window_size) {
+          ulii -= max_window_size;
+        }
+        count_flush = (ulii == window_cidx);
       }
       marker_uidx2 = window_uidxs[window_cidx2];
-      if (((ulii == window_cidx) && (prev_marker_uidx != marker_uidx2)) || (marker_pos[marker_uidx2] < marker_pos_thresh)) {
+      if ((count_flush && (prev_marker_uidx != marker_uidx2)) || (marker_pos[marker_uidx2] < marker_pos_thresh)) {
 	do {
 	  pos_r_tot = 0.0;
 	  neg_r_tot = 0.0;


### PR DESCRIPTION
When `--flip-scan-window-kb` is the binding constraint rather than `--flip-scan-window`, every window on the chromosome comes out shorter than either flag allows.

`max_window_size` is sized from the data, as the largest number of markers the doubled bp window holds anywhere, capped at `2 * max_window_locus_ct + 1`. On sparse data that can be smaller than `max_window_locus_ct + 1`, and then the locus-count flush test

```c
ulii = window_cidx2 + max_window_locus_ct;
if (ulii >= max_window_size) {
  ulii -= max_window_size;
}
```

stops describing the locus count: one subtraction leaves `window_cidx2 + (max_window_locus_ct % max_window_size)`, so the trailing marker is flushed after that many further markers.

The count constraint cannot legitimately bind in that case, since the live window spans at most `window_bp` and so never holds more than `max_window_size` markers, so the fix skips the test instead of repairing the arithmetic.

40 variants on one chromosome, the first seven inside 52 kb, `--flip-scan --flip-scan-window 10 --flip-scan-window-kb 50`:

| variant | POS before | POS after |
|---|---|---|
| v1_0 | 2 | 4 |
| v1_1 | 3 | 5 |
| v1_2 | 4 | 6 |
| v1_3 | 4 | 6 |
| v1_4 | 4 | 6 |

The "after" column is what the 50 kb window allows; before the fix the scan behaved as though `--flip-scan-window 3` had been given, and `--flip-scan-window` had no effect at all on this dataset.

Found by fuzzing `--flip-scan` against an independent Python implementation of the scan (window membership, pairwise-complete case and control correlations, the POS/NEG split, `R_POS`/`R_NEG`, the `NEGSNPS` list and the `verbose` file). 240 runs over 40 datasets and 6 window/threshold configurations: 22 disagreed before this change, 0 after. The disagreements were all on configurations where the kb window binds, and the fixed binary agrees with the oracle on the other configurations too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)