### PR TITLE
1.9: drop weight-0 variants from --distance-wts's variant set

### DIFF
--- a/1.9/plink_calc.c
+++ b/1.9/plink_calc.c
@@ -6315,7 +6315,21 @@ int32_t load_distance_wts(char* distance_wts_fname, uintptr_t unfiltered_marker_
     goto load_distance_wts_ret_READ_FAIL;
   }
   bigstack_reset(bigstack_mark);
-  marker_ct = popcount_longs(marker_include, unfiltered_marker_ctl) - zcount;
+  // bugfix (10 Sep 2026): weight-0 variants were left in marker_include while
+  // being subtracted from marker_ct, so the caller iterated over marker_ct
+  // included variants and read main_weights[] in order.  Every weight past the
+  // first zero was then applied to the wrong variant, and the last zcount
+  // included variants were dropped from the calculation instead of the
+  // weight-0 ones.  They have to leave marker_include too; they are only in it
+  // so that a repeated ID is still caught above.
+  if (zcount) {
+    for (marker_uidx = 0; marker_uidx < unfiltered_marker_ct; marker_uidx++) {
+      if (is_set(marker_include, marker_uidx) && (main_weights_tmp[marker_uidx] == 0.0)) {
+        clear_bit(marker_uidx, marker_include);
+      }
+    }
+  }
+  marker_ct = popcount_longs(marker_include, unfiltered_marker_ctl);
   if (!marker_ct) {
     logerrprint("Error: No valid nonzero entries in --distance-wts file.\n");
     goto load_distance_wts_ret_INVALID_FORMAT;
@@ -6334,13 +6348,9 @@ int32_t load_distance_wts(char* distance_wts_fname, uintptr_t unfiltered_marker_
   }
   dptr = *main_weights_ptr;
   *marker_ct_ptr = marker_ct;
-  for (marker_uidx = 0, marker_idx = 0; marker_idx < marker_ct; marker_uidx++) {
+  for (marker_uidx = 0, marker_idx = 0; marker_idx < marker_ct; marker_uidx++, marker_idx++) {
     next_set_unsafe_ck(marker_include, &marker_uidx);
-    dxx = main_weights_tmp[marker_uidx];
-    if (dxx != 0.0) {
-      *dptr++ = dxx;
-      marker_idx++;
-    }
+    *dptr++ = main_weights_tmp[marker_uidx];
   }
   while (0) {
   load_distance_wts_ret_NOMEM:


### PR DESCRIPTION
A weight-0 entry in a `--distance-wts` file corrupts the weights of every variant after it.

`load_distance_wts()` leaves weight-0 variants in `marker_include` while subtracting them from `marker_ct`:

```c
marker_ct = popcount_longs(marker_include, unfiltered_marker_ctl) - zcount;
...
bitarr_invert_copy(marker_include, unfiltered_marker_ct, *marker_exclude_ptr);
```

The include set therefore has `marker_ct + zcount` members. The caller walks `marker_ct` of them and reads `main_weights[]` in order, so every weight past the first zero lands on the wrong variant, and the last `zcount` included variants are dropped from the calculation instead of the weight-0 ones.

They are only in `marker_include` so that a repeated ID is still caught during parsing, so clearing them afterwards is enough; `marker_ct` becomes the plain popcount and the weight-copy loop no longer has to skip anything.

Reproducer: 60 samples and 300 variants, weights all 1 except ten zeros. Since the surviving weights are equal, the answer has to equal `--exclude <those ten> --distance flat-missing`:

| | max abs difference from that reference |
|---|---|
| before | 10 |
| after | 0 (bit-identical) |

Found while porting `--distance-wts` to 2.0. A 300-run differential between the fixed 1.9 and that port (5 weight forms, 3 report kinds, 20 datasets, complete data) now agrees to 1e-15 relative; before this change the weight-file forms disagreed by up to 26%.

There is a second, unrelated problem in the same feature which I have not touched here: with missing calls present, the weighted path disagrees with the unweighted one even when every weight is equal. I will open that separately with a reproducer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
