### PR TITLE
1.9: make --ibs-test read a loaded distance matrix as distances

### DIFF
--- a/1.9/plink.c
+++ b/1.9/plink.c
@@ -1827,7 +1827,7 @@ int32_t plink(char* outname, char* outname_end, char* bedname, char* bimname, ch
       retval = RET_CALC_NOT_YET_SUPPORTED;
       goto plink_ret_1;
     }
-    retval = ibs_test_calc(threads, read_dists_fname, unfiltered_sample_ct, sample_exclude, sample_ct, ibs_test_perms, pheno_nm_ct, pheno_ctrl_ct, pheno_nm, pheno_c);
+    retval = ibs_test_calc(threads, read_dists_fname, marker_ct, unfiltered_sample_ct, sample_exclude, sample_ct, ibs_test_perms, pheno_nm_ct, pheno_ctrl_ct, pheno_nm, pheno_c);
     if (retval) {
       goto plink_ret_1;
     }

--- a/1.9/plink_calc.c
+++ b/1.9/plink_calc.c
@@ -763,7 +763,6 @@ static double* g_ibs_test_partial_sums;
 static double* g_perm_results;
 static uintptr_t g_perm_ct;
 static double g_half_marker_ct_recip;
-static uint32_t g_load_dists;
 static unsigned char* g_generic_buf;
 
 void ibs_test_init_col_buf(uintptr_t row_idx, uintptr_t perm_ct, uintptr_t* perm_rows, uintptr_t* perm_col_buf) {
@@ -788,7 +787,7 @@ void ibs_test_init_col_buf(uintptr_t row_idx, uintptr_t perm_ct, uintptr_t* perm
   } while (perm_idx < perm_ct);
 }
 
-double fill_psbuf(uintptr_t block_size, double half_marker_ct_recip, uint32_t load_dists, uintptr_t* pheno_nm, uintptr_t* pheno_c, double* dists, uintptr_t* col_uidxp, double* psbuf, double* ssq0p) {
+double fill_psbuf(uintptr_t block_size, double half_marker_ct_recip, uintptr_t* pheno_nm, uintptr_t* pheno_c, double* dists, uintptr_t* col_uidxp, double* psbuf, double* ssq0p) {
   // also updates total sum and sums of squares
   double tot = 0.0;
   uintptr_t col_idx = 0;
@@ -810,11 +809,7 @@ double fill_psbuf(uintptr_t block_size, double half_marker_ct_recip, uint32_t lo
     subtot = 0.0;
     do {
       next_set_ul_unsafe_ck(pheno_nm, &col_uidx);
-      if (load_dists) {
-	dxx = dists[col_uidx];
-      } else {
-	dxx = 1.0 - dists[col_uidx] * half_marker_ct_recip;
-      }
+      dxx = 1.0 - dists[col_uidx] * half_marker_ct_recip;
       increment[sub_block_idx] = subtot - dxx;
       subtot += dxx;
       ssq[IS_SET(pheno_c, col_uidx)] += dxx * dxx;
@@ -912,7 +907,6 @@ void ibs_test_range(uint32_t tidx, uintptr_t* perm_col_buf, double* perm_results
   uintptr_t* perm_rows = g_perm_rows;
   double* dists = g_dists;
   double half_marker_ct_recip = g_half_marker_ct_recip;
-  uint32_t load_dists = g_load_dists;
   double ssq[3];
   double* dptr;
   double block_tot;
@@ -941,7 +935,7 @@ void ibs_test_range(uint32_t tidx, uintptr_t* perm_col_buf, double* perm_results
       } else {
 	block_size = BITCT;
       }
-      block_tot = fill_psbuf(block_size, half_marker_ct_recip, load_dists, pheno_nm, pheno_c, dptr, &col_uidx, psptr, &(ssq[row_set]));
+      block_tot = fill_psbuf(block_size, half_marker_ct_recip, pheno_nm, pheno_c, dptr, &col_uidx, psptr, &(ssq[row_set]));
       dist_tot += block_tot;
       ibs_test_process_perms(&(perm_rows[(col_idx / BITCT) * perm_ct]), perm_ct, (block_size + 7) / 8, block_tot, psptr, perm_col_buf, perm_results);
       col_idx += block_size;
@@ -2694,9 +2688,10 @@ int32_t unrelated_herit_batch(uint32_t load_grm_bin, char* grmname, char* phenon
 }
 #endif
 
-int32_t ibs_test_calc(pthread_t* threads, char* read_dists_fname, uintptr_t unfiltered_sample_ct, uintptr_t* sample_exclude, uintptr_t sample_ct, uintptr_t perm_ct, uintptr_t pheno_nm_ct, uintptr_t pheno_ctrl_ct, uintptr_t* pheno_nm, uintptr_t* pheno_c) {
-  // g_dists and g_half_marker_ct_recip assumed to be populated by
-  // calc_distance().
+int32_t ibs_test_calc(pthread_t* threads, char* read_dists_fname, uintptr_t marker_ct, uintptr_t unfiltered_sample_ct, uintptr_t* sample_exclude, uintptr_t sample_ct, uintptr_t perm_ct, uintptr_t pheno_nm_ct, uintptr_t pheno_ctrl_ct, uintptr_t* pheno_nm, uintptr_t* pheno_c) {
+  // g_dists is populated either by calc_distance() or by --read-dists, and
+  // holds distances in both cases; g_half_marker_ct_recip turns one into an
+  // IBS value, and calc_distance() only sets it when it runs.
   unsigned char* bigstack_mark = g_bigstack_base;
   uintptr_t unfiltered_sample_ctl = BITCT_TO_WORDCT(unfiltered_sample_ct);
   uintptr_t pheno_nm_ctl = BITCT_TO_WORDCT(pheno_nm_ct);
@@ -2746,7 +2741,13 @@ int32_t ibs_test_calc(pthread_t* threads, char* read_dists_fname, uintptr_t unfi
   double* rptr2;
 #endif
   uintptr_t perm_idx;
-  g_load_dists = read_dists_fname? 1 : 0;
+  if (read_dists_fname) {
+    // --read-dists skipped calc_distance(), so the scale factor it would have
+    // computed has to be set here.  A matrix written by --distance on this
+    // same dataset then gives exactly the same report as recalculating, which
+    // is what --read-dists promises.
+    g_half_marker_ct_recip = 0.5 / ((double)((intptr_t)marker_ct));
+  }
   g_sample_ct = sample_ct;
   perm_ct += 1; // first permutation = original config
   if (pheno_ctrl_ct < 2) {

--- a/1.9/plink_calc.h
+++ b/1.9/plink_calc.h
@@ -68,7 +68,7 @@ int32_t calc_unrelated_herit(uint64_t calculation_type, Rel_info* relip, uintptr
 int32_t unrelated_herit_batch(uint32_t load_grm_bin, char* grmname, char* phenoname, uint32_t mpheno_col, char* phenoname_str, int32_t missing_pheno, Rel_info* relip);
 #endif
 
-int32_t ibs_test_calc(pthread_t* threads, char* read_dists_fname, uintptr_t unfiltered_sample_ct, uintptr_t* sample_exclude, uintptr_t sample_ct, uintptr_t perm_ct, uintptr_t pheno_nm_ct, uintptr_t pheno_ctrl_ct, uintptr_t* pheno_nm, uintptr_t* pheno_c);
+int32_t ibs_test_calc(pthread_t* threads, char* read_dists_fname, uintptr_t marker_ct, uintptr_t unfiltered_sample_ct, uintptr_t* sample_exclude, uintptr_t sample_ct, uintptr_t perm_ct, uintptr_t pheno_nm_ct, uintptr_t pheno_ctrl_ct, uintptr_t* pheno_nm, uintptr_t* pheno_c);
 
 int32_t groupdist_calc(pthread_t* threads, uint32_t unfiltered_sample_ct, uintptr_t* sample_exclude, uintptr_t sample_ct, uintptr_t groupdist_iters, uint32_t groupdist_d, uint32_t pheno_nm_ct, uint32_t pheno_ctrl_ct, uintptr_t* pheno_nm, uintptr_t* pheno_c);
 


### PR DESCRIPTION
`--read-dists` is documented as loading a distance matrix "instead of recalculating from scratch", and `--cluster`, `--neighbour`, `--groupdist` and `--regress-distance` all treat what it loads as distances. `--ibs-test` uses the loaded values directly as IBS values:

```c
if (load_dists) {
  dxx = dists[col_uidx];
} else {
  dxx = 1.0 - dists[col_uidx] * half_marker_ct_recip;
}
```

The branch exists because `g_half_marker_ct_recip` is only set inside `calc_distance()`, which `--read-dists` skips. The effect is that the same dataset gives opposite answers depending on which way the matrix got there.

On 120 samples and 200 variants, writing the matrix out and reading it straight back in:

```
$ plink --bfile i --ibs-test 2000
  Between-group IBS (mean, SD)   = 0.716504, 0.0211036
     T1: Case/control less similar                p = 0.942529
     T2: Case/control more similar                p = 0.0574713

$ plink --bfile i --distance triangle bin
$ plink --bfile i --read-dists plink.dist.bin --ibs-test 2000
  Between-group IBS (mean, SD)   = 113.398, 8.44143
     T1: Case/control less similar                p = 0.053973
     T2: Case/control more similar                p = 0.946027
```

113.398 is `(1 - 0.716504) * 2 * 200`, the same numbers on the distance scale, printed under the IBS label. Since a larger distance is *less* similarity, every one of the twelve one-sided tests inverts. Nothing warns, and the variance ratio is unchanged (it is invariant under the linear transform), so the report looks self-consistent.

### The fix

Set the scale factor from the current marker count when `--read-dists` is used, and let the load path take the same branch as the computed one. A matrix written by `--distance` on the same dataset then gives a **byte-identical** report, permutation p-values included, which is what `--read-dists` promises.

A matrix from a different marker set is mis-scaled in the printed means either way, but at least the twelve tests then point the right way round. If you would rather reject `--ibs-test` with `--read-dists` outright, or treat the loaded matrix as an IBS matrix and say so in the help, either is a one-line change from here; I went with the reading that makes `--read-dists` an optimization rather than a different analysis.

### Testing

The computed path was checked against an independent Python oracle written from the method rather than from plink's output: the three group means, their standard deviations and the variance ratio agree exactly over random filesets with and without missing calls. That includes the weighted missingness correction, `wsum / (wsum - wmiss_i - wmiss_j + wboth_ij)` with per-marker weight `q(1-q)(q^2-q+1)` normalized to integers summing to just under 2^32; a per-pair marker count instead of that weighted one is wrong in the fourth significant digit, which is how I know the oracle is reproducing the real thing.

The twelve permutation p-values cannot be reproduced exactly, so they are checked three ways: each pair of one-sided tests must sum to 1, each must be a multiple of 1/(perms + 1), and each must agree with an independent permutation test of my own within five sigma. Twelve random filesets (20 to 70 cases and controls, 100 to 500 variants, 0-15% missingness, 2000 permutations) pass all three, and the `--distance triangle bin` round trip is identical on every one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
