### PR TITLE
1.9: fix the swapped assignment in em_phase_hethet()'s root selection

### DIFF
--- a/1.9/plink_ld.c
+++ b/1.9/plink_ld.c
@@ -4999,7 +4999,7 @@ uint32_t em_phase_hethet(double known11, double known12, double known21, double 
 	incr_1122 = solutions[cur_sol_idx];
         cur_lnlike = calc_lnlike(known11, known12, known21, known22, center_ct_d, freq11, freq12, freq21, freq22, half_hethet_share, incr_1122);
 	if (cur_lnlike > best_lnlike) {
-          cur_lnlike = best_lnlike;
+          best_lnlike = cur_lnlike;
           best_sol = incr_1122;
 	}
       } while (++cur_sol_idx < sol_end_idx);


### PR DESCRIPTION
`em_phase_hethet()`'s root-selection loop never updates the value it compares against:

```c
best_lnlike = calc_lnlike(..., best_sol);
cur_sol_idx = sol_start_idx + 1;
do {
  incr_1122 = solutions[cur_sol_idx];
  cur_lnlike = calc_lnlike(..., incr_1122);
  if (cur_lnlike > best_lnlike) {
    cur_lnlike = best_lnlike;     // assigns the wrong way round
    best_sol = incr_1122;
  }
} while (++cur_sol_idx < sol_end_idx);
```

`cur_lnlike = best_lnlike` is a dead store: `cur_lnlike` is overwritten at the top of the next iteration, and `best_lnlike` keeps the first root's value forever. With three candidate roots the third is therefore compared against the *first* root's likelihood rather than against the running best. 2.0's `EmPhaseHethet()` does the same loop correctly, which is what made me look twice.

**This cannot change any current output.** The cubic's roots are the stationary points of the very likelihood being maximized, so they alternate maximum, minimum, maximum, and the best is always an endpoint. Whenever the third root is the best it also beats the first, so it wins the comparison as written; the case that would break, the middle root being the maximum, cannot occur. I checked that empirically as well as by the argument: over 200000 random two-locus tables, 2058 had three in-range roots, and the maximum was root 0 or root 2 every time, never the middle one.

So this is a latent fix rather than a behavioural one, and I would understand closing it. The reason I am sending it: the function feeds `--r2 dprime`, `--ld`, `--test-mishap`, `--blocks` and `--show-tags`, and what keeps the typo harmless is a property of the cubic rather than anything local to the loop. `--blocks` output is unchanged across the 25-dataset differential test below.

### How I got here

Writing an independent oracle for `--blocks`: Haploview's reading of Gabriel et al., with the one-sided 90% D' confidence interval from the profile likelihood over D' in hundredths, the pair labels (recombination below 0.89 highCI, informative at 0.97/0.52, strong at 0.97/0.72), the size-2 and size-3 special cases with their 20kb and 30kb span limits, the 95%-of-informative-pairs rule for longer blocks, and the longest-span-first greedy selection.

It reproduces `--blocks` exactly on 25 generated filesets (30 to 70 variants, 120 to 300 samples, one or two chromosomes, 0-15% missing calls, with and without `no-pheno-req` and `no-small-max-span`, non-founders and missing phenotypes mixed in), block by block: positions, variant counts and membership. Also on hand-built span edges: a pair exactly 20000 bp apart forms a block and one 20001 bp apart does not, unless `no-small-max-span` is given.

`--simulate` draws independent variants and so never produces a block; the test data comes from a small ancestral-haplotype walk with occasional ancestry switches and mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
